### PR TITLE
ci: drop invalid image_tag output from docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,6 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.build.outputs.tags }}
       image_digest: ${{ steps.build.outputs.digest }}
 
     steps:


### PR DESCRIPTION
## Summary

- `docker/build-push-action@v7` only exposes `imageid`, `digest`, `metadata` — not `tags`. The job-level output `image_tag: \${{ steps.build.outputs.tags }}` therefore always resolved to an empty string.
- Drop the broken line. `image_digest` stays (output is valid; left in place in case a consumer wants it later).

## Why this is safe

No caller reads this output. Verified across all workflows in the repo:

\`\`\`sh
for f in ci.yml clean.yml docker-security.yml quality.yml update.yml; do
  gh api /repos/oszuidwest/zwfm-liquidsoap/contents/.github/workflows/\$f --jq '.content' | base64 -d | grep image_tag
done
\`\`\`

Returns nothing. `update.yml` only triggers `docker.yml` via `gh workflow run`; no workflow `uses:` it.

## Test plan

- [x] No consumers grep-confirmed
- [ ] CI on this PR is green