### PR TITLE
Apply system hardening baseline in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,6 +111,10 @@ if [ "${DO_UPDATES}" == "y" ]; then
   apt_update --silent
 fi
 
+if declare -F set_system_hardening_baseline > /dev/null; then
+  set_system_hardening_baseline --silent
+fi
+
 # Create required directories
 echo -e "${BLUE}►► Creating directories...${NC}"
 for dir in "${DIRECTORIES[@]}"; do


### PR DESCRIPTION
## Summary
- call `set_system_hardening_baseline --silent` from the relevant Linux/Pi installer script(s)
- guard the call with `declare -F` so the installer remains compatible until the shared helper is merged
- uses the baseline added in https://github.com/oszuidwest/bash-functions/pull/14: disk health tooling, smart monitoring, and journald `SystemMaxUse=512M`

## Tests
- `bash -n install.sh`
- `shellcheck install.sh`