### PR TITLE
feat: apply time sync and journald setters

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,9 +81,11 @@ assert_user_privileged "root"
 assert_os_linux
 assert_os_64bit
 
-# Configure host time settings and journald storage limits
+# Configure host time settings
 set_timezone "${TIMEZONE}"
 set_time_sync
+
+# Configure journald storage limits
 set_journald_limits
 
 # Ensure Docker is installed

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,8 @@ assert_user_privileged "root"
 assert_os_linux
 assert_os_64bit
 set_timezone "${TIMEZONE}"
+set_time_sync
+set_journald_limits
 
 # Ensure Docker is installed
 assert_tool "docker"

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,8 @@ set_colors
 assert_user_privileged "root"
 assert_os_linux
 assert_os_64bit
+
+# Configure host time settings and journald storage limits
 set_timezone "${TIMEZONE}"
 set_time_sync
 set_journald_limits


### PR DESCRIPTION
## Summary
- call `set_time_sync` during installation to enable system time synchronization where supported
- call `set_journald_limits` to apply the default journald storage limits from `bash-functions`
- use the smaller helpers merged in oszuidwest/bash-functions#15 instead of the earlier broad hardening baseline

## Validation
- `bash -n` on the modified installer script
- `shellcheck` on the modified installer script
- `git diff --check`