### PR TITLE
fix: install socat for runtime control

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The system delivers audio through dual redundant pathways. Liquidsoap prioritize
 - x86_64 or ARM64 architecture
 - At least 2GB RAM and 10GB disk space
 - Network connectivity for SRT streams
-- `socat` for runtime control via server socket (optional)
+- `socat` for runtime control via server socket (installed by the installer)
 
 ### Quick Install
 

--- a/install.sh
+++ b/install.sh
@@ -170,9 +170,9 @@ if ! file_download "${AUDIO_FALLBACK_URL}" "${AUDIO_FALLBACK_PATH}" "audio fallb
   exit 1
 fi
 
-# Always install StereoTool (whether it's used depends on STEREOTOOL_LICENSE_KEY in .env)
-echo -e "${BLUE}►► Installing StereoTool...${NC}"
-apt_install --silent unzip
+# Install host tools used for StereoTool setup and runtime control.
+echo -e "${BLUE}►► Installing dependencies...${NC}"
+apt_install --silent unzip socat
 
 
 # Create installation directory


### PR DESCRIPTION
## Summary
- Install `socat` by default with the host dependencies used by the installer.
- Keep the runtime-control socket instructions usable immediately after installation.
- Update the README requirement note to show that the installer provides `socat`.

## Validation
- `bash -n install.sh`
- `shellcheck install.sh`
- `git diff --check`