### PR TITLE
feat: add Bunny-backed HLS output

### DIFF
--- a/.env.bredanu.example
+++ b/.env.bredanu.example
@@ -111,6 +111,13 @@ DME_MOUNT_POINT=/xxxx
 # DAB_METADATA_SOCKET=padenc.sock
 
 # ====================
+# HLS OUTPUT
+# ====================
+# HLS_BUNNY_STORAGE_ZONE=zwfm-hls
+# HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
+# HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+
+# ====================
 # DOCKER CONFIGURATION
 # ====================
 

--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,29 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # DAB_METADATA_SOCKET=/tmp/pad.sock
 
 # ====================
+# HLS OUTPUT
+# ====================
+# HTTP Live Streaming via Bunny Edge Storage + Bunny CDN
+# Feature is disabled unless both STORAGE_ZONE and ACCESS_KEY are set
+
+# [OPTIONAL] Bunny Edge Storage credentials - both required to enable HLS
+# HLS_BUNNY_STORAGE_ZONE=zwfm-hls
+# HLS_BUNNY_ACCESS_KEY=storage-zone-read-write-password
+
+# [OPTIONAL] Bunny Edge Storage endpoint
+# Use the endpoint shown by Bunny for the storage zone region
+# HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+
+# [OPTIONAL] Local HLS window and bitrate ladder
+# HLS_DIR=/hls
+# HLS_BITRATE_LOW=48
+# HLS_BITRATE_MID=96
+# HLS_BITRATE_HIGH=192
+# HLS_SEGMENT_DURATION=4.0
+# HLS_SEGMENTS=10
+# HLS_SEGMENTS_OVERHEAD=5
+
+# ====================
 # DUTCH MEDIA EXCHANGE (DME)
 # ====================
 # Special configuration for Dutch public broadcasters
@@ -172,6 +195,7 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # Optional features (uncomment to enable):
 # - StereoTool audio processing (needs license)
 # - DAB+ digital radio output (needs both bitrate and destination)
+# - HLS output via Bunny Edge Storage (needs storage zone and access key)
 # - DME output (only for specific Dutch stations)
 
 # ====================

--- a/.env.rucphen.example
+++ b/.env.rucphen.example
@@ -49,3 +49,10 @@ DME_MOUNT_POINT=/xxx
 DAB_BITRATE=96
 DAB_EDI_DESTINATIONS=tcp://localhost:6000
 DAB_METADATA_SOCKET=padenc.sock
+
+# ====================
+# HLS OUTPUT
+# ====================
+# HLS_BUNNY_STORAGE_ZONE=zwfm-hls
+# HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
+# HLS_BUNNY_ENDPOINT=storage.bunnycdn.com

--- a/.env.zuidwest.example
+++ b/.env.zuidwest.example
@@ -37,3 +37,10 @@ DAB_BITRATE=96
 DAB_EDI_DESTINATIONS=tcp://localhost:9001,tcp://localhost:9002
 DAB_METADATA_SIZE=8
 DAB_METADATA_SOCKET=padenc.sock
+
+# ====================
+# HLS OUTPUT
+# ====================
+# HLS_BUNNY_STORAGE_ZONE=zwfm-hls
+# HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
+# HLS_BUNNY_ENDPOINT=storage.bunnycdn.com

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 package.json
 package-lock.json
+hls/
 
 # Ignore all markdown files except README
 *.md

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a professional-grade audio streaming solution originall
 
 - **High-availability streaming** with automatic failover between multiple inputs
 - **Professional audio processing** via StereoTool (optional)
-- **Multiple output formats**: Icecast streaming (MP3/AAC), DAB+ encoding, and MicroMPX for FM transmitters
+- **Multiple output formats**: Icecast streaming (MP3/AAC), HLS streaming, DAB+ encoding, and MicroMPX for FM transmitters
 - **Docker-based deployment** for easy installation and management
 
 While originally designed for these three Dutch radio stations, the system is fully configurable for any radio station's needs.
@@ -25,6 +25,8 @@ flowchart LR
     subgraph outputs [" Outputs "]
         MICROMPX["MICROMPX"]
         ICECAST["ICECAST"]
+        HLS["HLS"]
+        BUNNY["BUNNY CDN"]
         ODR["ODR-AUDIOENC"]
     end
 
@@ -40,6 +42,8 @@ flowchart LR
 
     LIQUIDSOAP --> MICROMPX
     LIQUIDSOAP --> ICECAST
+    LIQUIDSOAP --> HLS
+    HLS --> BUNNY
     LIQUIDSOAP --> ODR
 
     ODR <--> PADENC
@@ -50,7 +54,7 @@ flowchart LR
     classDef gray fill:#757575,stroke:#424242,color:#fff
     classDef pink fill:#E91E8A,stroke:#AD1457,color:#fff
 
-    class SRT1,SRT2,FALLBACK,LIQUIDSOAP,MICROMPX,ICECAST,ODR blue
+    class SRT1,SRT2,FALLBACK,LIQUIDSOAP,MICROMPX,ICECAST,HLS,BUNNY,ODR blue
     class PADENC,PADAPI gray
     class ZWFM pink
 ```
@@ -63,8 +67,9 @@ The system delivers audio through dual redundant pathways. Liquidsoap prioritize
 
 1. **Liquidsoap**: Core audio processing engine - handles input switching, fallback logic, and encoding
 2. **Icecast**: Public streaming server for distributing MP3/AAC streams to listeners
-3. **StereoTool**: Professional audio processor and [MicroMPX](https://www.thimeo.com/micrompx/) encoder for FM transmitters (optional, requires license)
-4. **ODR-AudioEnc**: DAB+ audio encoder for digital radio broadcasting (optional)
+3. **HLS**: Optional HTTP Live Streaming output mirrored to Bunny Edge Storage and served through Bunny CDN
+4. **StereoTool**: Professional audio processor and [MicroMPX](https://www.thimeo.com/micrompx/) encoder for FM transmitters (optional, requires license)
+5. **ODR-AudioEnc**: DAB+ audio encoder for digital radio broadcasting (optional)
 
 ### Related Projects
 
@@ -142,6 +147,17 @@ This table lists ALL environment variables used in the system. Variables without
 | `DAB_EDI_DESTINATIONS`            | DAB+ EDI destination(s)                          | _(none)_                     | `tcp://dab-mux.local:9001` or `tcp://dab1:9001,tcp://dab2:9002` | `conf/lib/00_settings.liq`             | All             |
 | `DAB_METADATA_SIZE`               | PAD size in bytes (0-196)                        | `8` when socket is set       | `16`                                                            | `conf/lib/00_settings.liq`             | All             |
 | `DAB_METADATA_SOCKET`             | PAD metadata socket path                         | _(none)_                     | `padenc.sock`                                                   | `conf/lib/00_settings.liq`             | All             |
+| **HLS Configuration (Optional)**  |
+| `HLS_BUNNY_STORAGE_ZONE`          | Bunny Edge Storage zone name                     | _(none)_                     | `zwfm-hls`                                                      | `conf/lib/00_settings.liq`             | All             |
+| `HLS_BUNNY_ACCESS_KEY`            | Bunny Edge Storage read/write password           | _(none)_                     | `secret-storage-password`                                       | `conf/lib/00_settings.liq`             | All             |
+| `HLS_BUNNY_ENDPOINT`              | Bunny Edge Storage API endpoint                  | `storage.bunnycdn.com`       | `storage.bunnycdn.com`                                          | `conf/lib/00_settings.liq`             | All             |
+| `HLS_DIR`                         | Local HLS output directory                       | `/hls`                       | `/hls`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `HLS_BITRATE_LOW`                 | Low HLS AAC bitrate in kbps                      | `48`                         | `48`                                                            | `conf/lib/00_settings.liq`             | All             |
+| `HLS_BITRATE_MID`                 | Mid HLS AAC bitrate in kbps                      | `96`                         | `96`                                                            | `conf/lib/00_settings.liq`             | All             |
+| `HLS_BITRATE_HIGH`                | High HLS AAC bitrate in kbps                     | `192`                        | `192`                                                           | `conf/lib/00_settings.liq`             | All             |
+| `HLS_SEGMENT_DURATION`            | HLS segment duration in seconds                  | `4.0`                        | `4.0`                                                           | `conf/lib/00_settings.liq`             | All             |
+| `HLS_SEGMENTS`                    | Segments per live playlist                       | `10`                         | `10`                                                            | `conf/lib/00_settings.liq`             | All             |
+| `HLS_SEGMENTS_OVERHEAD`           | Extra old segments retained locally              | `5`                          | `5`                                                             | `conf/lib/00_settings.liq`             | All             |
 | **DME Configuration**             |
 | `DME_PRIMARY_HOST`                | Primary DME server                               | _(required)_                 | `ingest1.dme.nl`                                                | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
 | `DME_PRIMARY_PORT`                | Primary DME port                                 | _(required)_                 | `8010`                                                          | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
@@ -158,7 +174,7 @@ This table lists ALL environment variables used in the system. Variables without
 ### Notes:
 
 - **Required variables**: Must be set in `.env` file or Liquidsoap will fail to start
-- **Optional features**: DAB+ output is optional - set both `DAB_BITRATE` and `DAB_EDI_DESTINATIONS` to enable. PAD metadata requires `DAB_METADATA_SOCKET`
+- **Optional features**: DAB+ output is optional - set both `DAB_BITRATE` and `DAB_EDI_DESTINATIONS` to enable. HLS output is optional - set both `HLS_BUNNY_STORAGE_ZONE` and `HLS_BUNNY_ACCESS_KEY` to enable. PAD metadata requires `DAB_METADATA_SOCKET`
 - **Multiple EDI outputs**: `DAB_EDI_DESTINATIONS` supports comma-separated values for sending to multiple DAB+ destinations simultaneously
 - **Station column**: "All" means used by all stations, "Rucphen/BredaNu" means used only by stations with DME
 - **Default conventions**: `#{VARIABLE}` means the value is interpolated from another variable
@@ -314,6 +330,57 @@ DAB_EDI_DESTINATIONS=tcp://primary.example.com:9001,tcp://backup.example.com:900
 
 PAD allows sending metadata like song titles and station logos alongside the audio. Recommendation to use as small of a METADATA_SIZE as possible. 8 bytes is enough to transmit a logo in a couple of seconds (ofcourse, how smaller the filesize the faster the logo will transmit). If you're using artwork, you might need to consider using a bigger METADATA_SIZE.
 
+## HLS Output via Bunny CDN
+
+The system supports optional audio-only HLS output. Liquidsoap writes a local HLS live window to `/hls`, then mirrors file changes to Bunny Edge Storage with native `http.put` and `http.delete` calls. No sidecar uploader or extra Docker image dependency is required.
+
+The HLS ladder is:
+
+- 48 kbps HE-AACv1 ADTS (`aac_48.m3u8`)
+- 96 kbps AAC-LC ADTS (`aac_96.m3u8`)
+- 192 kbps AAC-LC ADTS (`aac_192.m3u8`)
+
+The main playlist is `live.m3u8`, with 4 second segments and a 10 segment playlist by default. Expected listener latency is roughly 15-30 seconds with normal HLS client buffering.
+
+### Configuration
+
+Set both Bunny variables to enable HLS:
+
+```bash
+HLS_BUNNY_STORAGE_ZONE=zwfm-hls
+HLS_BUNNY_ACCESS_KEY=storage-zone-read-write-password
+HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+```
+
+The AccessKey is the storage zone read/write password. Use a dedicated Edge Storage zone for HLS so this credential is scoped to live-stream objects only.
+
+### Bunny Setup
+
+1. Create a Bunny Edge Storage zone, for example `zwfm-hls`. Falkenstein is a good main region for Dutch listeners.
+2. Copy the storage zone read/write password into `HLS_BUNNY_ACCESS_KEY` and set `HLS_BUNNY_ENDPOINT` to the endpoint shown by Bunny.
+3. Create a Bunny CDN pull zone connected to the storage zone and add the desired custom hostname.
+4. Enable CORS on the pull zone and include the `m3u8` and `aac` extensions.
+5. Add an edge rule for `*.m3u8` that overrides cache time to 1-2 seconds.
+6. Keep the default cache time for `.aac` segments long, for example 1 day. Segment names are timestamped and never reused.
+7. Do not enable Perma-Cache for this pull zone.
+
+Player URL pattern:
+
+```text
+https://hls.example.com/{STATION_ID}/live.m3u8
+```
+
+### Validation
+
+After enabling HLS, verify the public URL with:
+
+```bash
+ffprobe https://hls.example.com/zuidwest/live.m3u8
+curl -sI https://hls.example.com/zuidwest/live.m3u8
+```
+
+Expected results: three variants, AAC codec strings (`mp4a.40.5` and `mp4a.40.2`), playlist refreshes after the edge-rule TTL, and `.aac` segments are served with a longer cache lifetime.
+
 ## DME Integration (Dutch Media Exchange)
 
 Radio Rucphen and BredaNu require DME output for distribution through the Dutch public broadcasting system. DME configuration is handled in station-specific configuration files.
@@ -366,6 +433,13 @@ For now-playing information and metadata routing, see the [zwfm-metadata](https:
 - Verify `ICECAST_HOST` and `ICECAST_PORT` are correct
 - Check `ICECAST_SOURCE_PASSWORD` matches server configuration
 - Ensure Icecast server is running and accessible
+
+**HLS playlist is stale or missing segments**
+
+- Verify `HLS_BUNNY_STORAGE_ZONE`, `HLS_BUNNY_ACCESS_KEY`, and `HLS_BUNNY_ENDPOINT`
+- Check Docker logs for `hls` upload, delete, or reconcile messages
+- Confirm the Bunny pull zone has a 1-2 second cache rule for `*.m3u8`
+- Confirm CORS includes `m3u8` and `aac` extensions
 
 **StereoTool not processing**
 
@@ -423,4 +497,3 @@ Copyright 2026 Omroepstichting ZuidWest & Stichting BredaNu. This project is lic
 - [Icecast](https://icecast.org/) - Reliable streaming server
 - [StereoTool](https://www.stereotool.com/) - Professional audio processing
 - [Opendigitalradio](https://www.opendigitalradio.org/) - DAB+ tools and community
-

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ PAD allows sending metadata like song titles and station logos alongside the aud
 
 ## HLS Output via Bunny CDN
 
-The system supports optional audio-only HLS output. Liquidsoap writes a local HLS live window to `/hls`, then mirrors file changes to Bunny Edge Storage with native `http.put` and `http.delete` calls. No sidecar uploader or extra Docker image dependency is required.
+The system supports optional audio-only HLS output. Liquidsoap writes a local HLS live window to `/hls`, then mirrors it to Bunny Edge Storage with native `http.put` and `http.delete` calls. No sidecar uploader or extra Docker image dependency is required.
 
 The HLS ladder is:
 
@@ -341,6 +341,8 @@ The HLS ladder is:
 - 192 kbps AAC-LC ADTS (`aac_192.m3u8`)
 
 The main playlist is `live.m3u8`, with 4 second segments and a 10 segment playlist by default. Expected listener latency is roughly 15-30 seconds with normal HLS client buffering.
+
+The mirror loop prioritizes consistency over freshness: segment uploads must succeed before playlists that reference them are published. During a Bunny upload failure, listeners may see an older playlist until the missing segment uploads or leaves the live window, instead of seeing a fresh playlist with a segment 404.
 
 ### Configuration
 
@@ -363,6 +365,8 @@ The AccessKey is the storage zone read/write password. Use a dedicated Edge Stor
 5. Add an edge rule for `*.m3u8` that overrides cache time to 1-2 seconds.
 6. Keep the default cache time for `.aac` segments long, for example 1 day. Segment names are timestamped and never reused.
 7. Do not enable Perma-Cache for this pull zone.
+
+When changing the HLS ladder names, clean the station prefix in Bunny Edge Storage once. Runtime cleanup removes stale segments, but old variant playlist files from previous ladder names are intentionally left alone.
 
 Player URL pattern:
 

--- a/conf/bredanu.liq
+++ b/conf/bredanu.liq
@@ -11,6 +11,7 @@
 %include "lib/50_processing.liq"
 %include "lib/60_output_icecast.liq"
 %include "lib/61_output_dab.liq"
+%include "lib/62_output_hls.liq"
 %include "lib/80_server.liq"
 %include "lib/90_radio.liq"
 
@@ -133,3 +134,6 @@ output_icecast_stream(
 
 # DAB+ output
 output_dab_stream(radio_processed)
+
+# HLS output
+output_hls_stream(radio_processed)

--- a/conf/lib/00_settings.liq
+++ b/conf/lib/00_settings.liq
@@ -62,5 +62,26 @@ let DAB_EDI_DESTINATIONS = environment.get("DAB_EDI_DESTINATIONS", default="")
 let DAB_METADATA_SOCKET = environment.get("DAB_METADATA_SOCKET", default="")
 let DAB_METADATA_SIZE = environment.get("DAB_METADATA_SIZE", default="")
 
+# HLS configuration (optional - storage zone and access key required to enable)
+let HLS_BUNNY_STORAGE_ZONE =
+  environment.get("HLS_BUNNY_STORAGE_ZONE", default="")
+let HLS_BUNNY_ACCESS_KEY =
+  environment.get("HLS_BUNNY_ACCESS_KEY", default="")
+let HLS_BUNNY_ENDPOINT =
+  environment.get("HLS_BUNNY_ENDPOINT", default="storage.bunnycdn.com")
+let HLS_DIR = environment.get("HLS_DIR", default="/hls")
+let HLS_BITRATE_LOW =
+  int_of_string(environment.get("HLS_BITRATE_LOW", default="48"))
+let HLS_BITRATE_MID =
+  int_of_string(environment.get("HLS_BITRATE_MID", default="96"))
+let HLS_BITRATE_HIGH =
+  int_of_string(environment.get("HLS_BITRATE_HIGH", default="192"))
+let HLS_SEGMENT_DURATION =
+  float_of_string(environment.get("HLS_SEGMENT_DURATION", default="4.0"))
+let HLS_SEGMENTS =
+  int_of_string(environment.get("HLS_SEGMENTS", default="10"))
+let HLS_SEGMENTS_OVERHEAD =
+  int_of_string(environment.get("HLS_SEGMENTS_OVERHEAD", default="5"))
+
 # StereoTool configuration (optional)
 let STEREOTOOL_LICENSE = environment.get("STEREOTOOL_LICENSE", default="")

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -201,6 +201,15 @@ def hls_playlist_segment_names(content) =
   )
 end
 
+def hls_snapshot_segment_names(playlists) =
+  list.fold(
+    fun (names, snapshot) ->
+      hls_union(names, hls_playlist_segment_names(snapshot.content)),
+    [],
+    playlists
+  )
+end
+
 def hls_remote_listing() =
   try
     let response =
@@ -378,12 +387,12 @@ def hls_upload_playlists(
   end
 end
 
-def hls_delete_stale_segments((synced_segments:ref), local_segment_names) =
+def hls_delete_stale_segments((synced_segments:ref), protected_segment_names) =
   list.iter(
     fun (remote_name) ->
       begin
         if
-          not list.mem(remote_name, local_segment_names)
+          not list.mem(remote_name, protected_segment_names)
         then
           if
             hls_delete_file(remote_name)
@@ -412,6 +421,8 @@ def hls_mirror_tick(
   let segment_files = hls_local_segment_files()
   let local_segment_names =
     list.map(fun (fname) -> path.basename(fname), segment_files)
+  let protected_segment_names =
+    hls_union(local_segment_names, hls_snapshot_segment_names(playlists))
 
   hls_upload_segments(synced_segments, segment_files)
 
@@ -422,7 +433,7 @@ def hls_mirror_tick(
   if
     playlists_ok
   then
-    hls_delete_stale_segments(synced_segments, local_segment_names)
+    hls_delete_stale_segments(synced_segments, protected_segment_names)
   end
 end
 

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -1,0 +1,439 @@
+# HLS output configuration
+# Writes a local HLS window and mirrors it to Bunny Edge Storage.
+
+let HLS_UPLOAD_QUEUE_MAX = 100
+let HLS_UPLOAD_SEGMENT_KEEP =
+  3 * (HLS_SEGMENTS + HLS_SEGMENTS_OVERHEAD + 2)
+let hls_upload_queue = ref([])
+let hls_bunny_headers = [("AccessKey", HLS_BUNNY_ACCESS_KEY)]
+
+def hls_enabled() =
+  HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
+end
+
+def hls_endpoint_host() =
+  let endpoint = string.trim(HLS_BUNNY_ENDPOINT)
+  let endpoint = string.residual(prefix="https://", endpoint) ?? endpoint
+  let endpoint = string.residual(prefix="http://", endpoint) ?? endpoint
+  r/\/+$/.replace(fun (_) -> "", endpoint)
+end
+
+def hls_remote_dir_url() =
+  "https://#{hls_endpoint_host()}/#{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/"
+end
+
+def hls_remote_url(remote_name) =
+  "#{hls_remote_dir_url()}#{remote_name}"
+end
+
+def hls_is_success(status_code) =
+  200 <= status_code and status_code < 300
+end
+
+def hls_is_sync_file_name(name) =
+  r/\.m3u8$/.test(name) or r/\.aac$/.test(name)
+end
+
+def hls_is_segment_upload(item) =
+  item.state != "deleted" and r/\.aac$/.test(path.basename(item.path))
+end
+
+def hls_trim_queue(queue) =
+  if
+    list.length(queue) <= HLS_UPLOAD_QUEUE_MAX
+  then
+    queue
+  else
+    let newest_first = list.rev(queue)
+    let (kept, segment_count, dropped_count) =
+      list.fold(
+        fun (state, item) ->
+          begin
+            let (kept, segment_count, dropped_count) = state
+            if
+              hls_is_segment_upload(item)
+            then
+              if
+                segment_count < HLS_UPLOAD_SEGMENT_KEEP
+              then
+                (item::kept, segment_count + 1, dropped_count)
+              else
+                (kept, segment_count, dropped_count + 1)
+              end
+            else
+              (item::kept, segment_count, dropped_count)
+            end
+          end,
+        ([], 0, 0),
+        newest_first
+      )
+    ignore(segment_count)
+
+    let kept =
+      if
+        list.length(kept) > HLS_UPLOAD_QUEUE_MAX
+      then
+        list.rev(list.prefix(HLS_UPLOAD_QUEUE_MAX, list.rev(kept)))
+      else
+        kept
+      end
+
+    log(
+      label="hls",
+      "HLS upload queue exceeded #{HLS_UPLOAD_QUEUE_MAX}; dropped #{
+        dropped_count
+      } stale segment upload(s), kept #{list.length(kept)} event(s)",
+      level=2
+    )
+    kept
+  end
+end
+
+def hls_upload_enqueue({state, path = changed_path}) =
+  let remote_name = path.basename(changed_path)
+  if
+    remote_name == "state.json" or not hls_is_sync_file_name(remote_name)
+  then
+    ()
+  else
+    hls_upload_queue :=
+      hls_trim_queue([
+        ...hls_upload_queue(),
+        {state=state, path=changed_path}
+      ])
+  end
+end
+
+def hls_put_file(local_path, remote_name) =
+  if
+    not file.exists(local_path)
+  then
+    log(
+      label="hls",
+      "Skipping HLS upload for missing local file #{local_path}",
+      level=3
+    )
+    false
+  else
+    try
+      let response =
+        http.put(
+          timeout=10.0,
+          headers=hls_bunny_headers,
+          data=file.contents(local_path),
+          hls_remote_url(remote_name)
+        )
+
+      if
+        hls_is_success(response.status_code)
+      then
+        true
+      else
+        log(
+          label="hls",
+          "HLS upload failed for #{remote_name}: HTTP #{
+            response.status_code
+          } #{response.status_message}",
+          level=2
+        )
+        false
+      end
+    catch err do
+      log(
+        label="hls",
+        "HLS upload exception for #{remote_name}: #{err.kind}: #{err.message}",
+        level=2
+      )
+      false
+    end
+  end
+end
+
+def hls_delete_file(remote_name) =
+  try
+    let response =
+      http.delete(
+        timeout=10.0,
+        headers=hls_bunny_headers,
+        hls_remote_url(remote_name)
+      )
+
+    if
+      hls_is_success(response.status_code) or response.status_code == 404
+    then
+      true
+    else
+      log(
+        label="hls",
+        "HLS delete failed for #{remote_name}: HTTP #{response.status_code} #{
+          response.status_message
+        }",
+        level=2
+      )
+      false
+    end
+  catch err do
+    log(
+      label="hls",
+      "HLS delete exception for #{remote_name}: #{err.kind}: #{err.message}",
+      level=2
+    )
+    false
+  end
+end
+
+def hls_retry_once(description, op) =
+  if
+    not op()
+  then
+    log(
+      label="hls",
+      "Retrying HLS #{description} once",
+      level=3
+    )
+
+    if
+      not op()
+    then
+      log(
+        label="hls",
+        "Giving up HLS #{description} after retry",
+        level=2
+      )
+    end
+  end
+end
+
+def hls_upload_with_retry(local_path) =
+  let remote_name = path.basename(local_path)
+  hls_retry_once(
+    "upload for #{remote_name}",
+    fun () -> hls_put_file(local_path, remote_name)
+  )
+end
+
+def hls_delete_with_retry(remote_name) =
+  hls_retry_once(
+    "delete for #{remote_name}",
+    fun () -> hls_delete_file(remote_name)
+  )
+end
+
+def hls_process_event(item) =
+  let remote_name = path.basename(item.path)
+  if
+    item.state == "deleted"
+  then
+    hls_delete_with_retry(remote_name)
+  elsif
+    item.state == "created" or item.state == "updated"
+  then
+    hls_upload_with_retry(item.path)
+  else
+    log(
+      label="hls",
+      "Ignoring unknown HLS file event #{item.state} for #{item.path}",
+      level=3
+    )
+  end
+end
+
+def hls_queue_pop() =
+  list.dcase(
+    hls_upload_queue(),
+    {null},
+    fun (item, rest) ->
+      begin
+        hls_upload_queue := rest
+        item
+      end
+  )
+end
+
+def hls_upload_worker() =
+  let item = hls_queue_pop()
+  if
+    null.defined(item)
+  then
+    hls_process_event(null.get(item))
+  end
+end
+
+def hls_local_files() =
+  if
+    file.exists(HLS_DIR)
+  then
+    list.filter(
+      fun (fname) ->
+        begin
+          let name = path.basename(fname)
+          not file.is_directory(fname) and hls_is_sync_file_name(name)
+        end,
+      file.ls(absolute=true, sorted=true, HLS_DIR)
+    )
+  else
+    []
+  end
+end
+
+def hls_local_names() =
+  list.map(fun (fname) -> path.basename(fname), hls_local_files())
+end
+
+def hls_reconcile() =
+  log(
+    label="hls",
+    "Reconciling local HLS window with Bunny Edge Storage prefix #{STATION_ID}/",
+    level=3
+  )
+
+  let local_names = hls_local_names()
+  try
+    let response =
+      http.get(
+        timeout=10.0,
+        headers=hls_bunny_headers,
+        hls_remote_dir_url()
+      )
+
+    if
+      hls_is_success(response.status_code)
+    then
+      let json.parse (remote_entries :
+        [{"ObjectName" as object_name: string}]
+      ) = response
+
+      list.iter(
+        fun ({object_name}) ->
+          begin
+            let remote_name = path.basename(object_name)
+            if
+              remote_name != ""
+              and remote_name != "."
+              and not list.mem(remote_name, local_names)
+            then
+              hls_delete_with_retry(remote_name)
+            end
+          end,
+        remote_entries
+      )
+    elsif
+      response.status_code == 404
+    then
+      log(
+        label="hls",
+        "Bunny HLS prefix #{STATION_ID}/ does not exist yet; local files \
+         will create it",
+        level=3
+      )
+    else
+      log(
+        label="hls",
+        "HLS reconcile listing failed: HTTP #{response.status_code} #{
+          response.status_message
+        }",
+        level=2
+      )
+    end
+  catch err do
+    log(
+      label="hls",
+      "HLS reconcile listing exception: #{err.kind}: #{err.message}",
+      level=2
+    )
+  end
+
+  list.iter(hls_upload_with_retry, hls_local_files())
+end
+
+def hls_segment_name(segment_metadata) =
+  let ts = int_of_float(time())
+  "#{segment_metadata.stream_name}_#{ts}_#{segment_metadata.position}.#{
+    segment_metadata.extname
+  }"
+end
+
+def output_hls_stream(audio_source) =
+  if
+    hls_enabled()
+  then
+    log(
+      label="hls",
+      "HLS output enabled - writing #{HLS_SEGMENTS}x#{
+        HLS_SEGMENT_DURATION
+      }s to #{HLS_DIR}, uploading to #{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/",
+      level=3
+    )
+
+    file.mkdir(parents=true, HLS_DIR)
+
+    # Buffer provides clock isolation from the live program chain.
+    let hls_source = mksafe(buffer(audio_source))
+
+    let aac_low =
+      %fdkaac(
+        channels = 2,
+        samplerate = 48000,
+        bitrate = HLS_BITRATE_LOW,
+        afterburner = true,
+        aot = 'mpeg4_he_aac',
+        transmux = 'adts'
+      ).{
+        bandwidth=HLS_BITRATE_LOW * 1000 + 8000,
+        codecs="mp4a.40.5",
+        extname="aac"
+      }
+
+    let aac_mid =
+      %fdkaac(
+        channels = 2,
+        samplerate = 48000,
+        bitrate = HLS_BITRATE_MID,
+        afterburner = true,
+        aot = 'mpeg4_aac_lc',
+        transmux = 'adts'
+      ).{
+        bandwidth=HLS_BITRATE_MID * 1000 + 8000,
+        codecs="mp4a.40.2",
+        extname="aac"
+      }
+
+    let aac_high =
+      %fdkaac(
+        channels = 2,
+        samplerate = 48000,
+        bitrate = HLS_BITRATE_HIGH,
+        afterburner = true,
+        aot = 'mpeg4_aac_lc',
+        transmux = 'adts'
+      ).{
+        bandwidth=HLS_BITRATE_HIGH * 1000 + 8000,
+        codecs="mp4a.40.2",
+        extname="aac"
+      }
+
+    let hls_output =
+      output.file.hls(
+        playlist="live.m3u8",
+        segment_duration=HLS_SEGMENT_DURATION,
+        segments=HLS_SEGMENTS,
+        segments_overhead=HLS_SEGMENTS_OVERHEAD,
+        segment_name=hls_segment_name,
+        persist_at="state.json",
+        HLS_DIR,
+        [("aac_48", aac_low), ("aac_96", aac_mid), ("aac_192", aac_high)],
+        hls_source
+      )
+
+    hls_output.on_file_change(synchronous=true, hls_upload_enqueue)
+    thread.run(fast=false, every=0.25, hls_upload_worker)
+    thread.run(fast=false, delay=5.0, hls_reconcile)
+  else
+    log(
+      label="hls",
+      "HLS output disabled - HLS_BUNNY_STORAGE_ZONE and/or \
+       HLS_BUNNY_ACCESS_KEY not configured",
+      level=3
+    )
+  end
+end

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -1,110 +1,88 @@
 # HLS output configuration
 # Writes a local HLS window and mirrors it to Bunny Edge Storage.
 
-let HLS_UPLOAD_QUEUE_MAX = 100
-let HLS_UPLOAD_SEGMENT_KEEP =
-  3 * (HLS_SEGMENTS + HLS_SEGMENTS_OVERHEAD + 2)
-let hls_upload_queue = ref([])
 let hls_bunny_headers = [("AccessKey", HLS_BUNNY_ACCESS_KEY)]
+let hls_main_playlist_name = "live.m3u8"
+let hls_endpoint_trimmed = string.trim(HLS_BUNNY_ENDPOINT)
+let hls_endpoint_without_https =
+  string.residual(prefix="https://", hls_endpoint_trimmed) ?? hls_endpoint_trimmed
+let hls_endpoint_without_scheme =
+  string.residual(prefix="http://", hls_endpoint_without_https) ??
+    hls_endpoint_without_https
+let hls_endpoint_host =
+  r/\/+$/.replace(fun (_) -> "", hls_endpoint_without_scheme)
 
-def hls_enabled() =
-  HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
-end
-
-def hls_endpoint_host() =
-  let endpoint = string.trim(HLS_BUNNY_ENDPOINT)
-  let endpoint = string.residual(prefix="https://", endpoint) ?? endpoint
-  let endpoint = string.residual(prefix="http://", endpoint) ?? endpoint
-  r/\/+$/.replace(fun (_) -> "", endpoint)
-end
-
-def hls_remote_dir_url() =
-  "https://#{hls_endpoint_host()}/#{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/"
-end
+let hls_remote_dir_url =
+  "https://#{hls_endpoint_host}/#{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/"
 
 def hls_remote_url(remote_name) =
-  "#{hls_remote_dir_url()}#{remote_name}"
+  "#{hls_remote_dir_url}#{remote_name}"
 end
 
 def hls_is_success(status_code) =
   200 <= status_code and status_code < 300
 end
 
+def hls_is_playlist_name(name) =
+  r/\.m3u8$/.test(name)
+end
+
+def hls_is_segment_name(name) =
+  r/\.aac$/.test(name)
+end
+
 def hls_is_sync_file_name(name) =
-  r/\.m3u8$/.test(name) or r/\.aac$/.test(name)
+  hls_is_playlist_name(name) or hls_is_segment_name(name)
 end
 
-def hls_is_segment_upload(item) =
-  item.state != "deleted" and r/\.aac$/.test(path.basename(item.path))
+def hls_add_unique(name, names) =
+  if list.mem(name, names) then names else [name, ...names] end
 end
 
-def hls_trim_queue(queue) =
-  if
-    list.length(queue) <= HLS_UPLOAD_QUEUE_MAX
-  then
-    queue
-  else
-    let newest_first = list.rev(queue)
-    let (kept, segment_count, dropped_count) =
-      list.fold(
-        fun (state, item) ->
-          begin
-            let (kept, segment_count, dropped_count) = state
-            if
-              hls_is_segment_upload(item)
-            then
-              if
-                segment_count < HLS_UPLOAD_SEGMENT_KEEP
-              then
-                (item::kept, segment_count + 1, dropped_count)
-              else
-                (kept, segment_count, dropped_count + 1)
-              end
-            else
-              (item::kept, segment_count, dropped_count)
-            end
-          end,
-        ([], 0, 0),
-        newest_first
+def hls_union(names, extra_names) =
+  list.fold(fun (acc, name) -> hls_add_unique(name, acc), names, extra_names)
+end
+
+def hls_assoc_set(key, value, values) =
+  [(key, value), ...list.assoc.remove.all(key, values)]
+end
+
+def hls_put_data(remote_name, data) =
+  try
+    let response =
+      http.put(
+        timeout=10.0,
+        headers=hls_bunny_headers,
+        data=data,
+        hls_remote_url(remote_name)
       )
-    ignore(segment_count)
 
-    let kept =
-      if
-        list.length(kept) > HLS_UPLOAD_QUEUE_MAX
-      then
-        list.rev(list.prefix(HLS_UPLOAD_QUEUE_MAX, list.rev(kept)))
-      else
-        kept
-      end
-
+    if
+      hls_is_success(response.status_code)
+    then
+      true
+    else
+      log(
+        label="hls",
+        "HLS upload failed for #{remote_name}: HTTP #{response.status_code} #{
+          response.status_message
+        }",
+        level=2
+      )
+      false
+    end
+  catch err do
     log(
       label="hls",
-      "HLS upload queue exceeded #{HLS_UPLOAD_QUEUE_MAX}; dropped #{
-        dropped_count
-      } stale segment upload(s), kept #{list.length(kept)} event(s)",
+      "HLS upload exception for #{remote_name}: #{err.kind}: #{err.message}",
       level=2
     )
-    kept
+    false
   end
 end
 
-def hls_upload_enqueue({state, path = changed_path}) =
-  let remote_name = path.basename(changed_path)
-  if
-    remote_name == "state.json" or not hls_is_sync_file_name(remote_name)
-  then
-    ()
-  else
-    hls_upload_queue :=
-      hls_trim_queue([
-        ...hls_upload_queue(),
-        {state=state, path=changed_path}
-      ])
-  end
-end
-
-def hls_put_file(local_path, remote_name) =
+def hls_put_file(local_path) =
+  let remote_name = path.basename(local_path)
   if
     not file.exists(local_path)
   then
@@ -116,32 +94,13 @@ def hls_put_file(local_path, remote_name) =
     false
   else
     try
-      let response =
-        http.put(
-          timeout=10.0,
-          headers=hls_bunny_headers,
-          data=file.contents(local_path),
-          hls_remote_url(remote_name)
-        )
-
-      if
-        hls_is_success(response.status_code)
-      then
-        true
-      else
-        log(
-          label="hls",
-          "HLS upload failed for #{remote_name}: HTTP #{
-            response.status_code
-          } #{response.status_message}",
-          level=2
-        )
-        false
-      end
+      hls_put_data(remote_name, file.contents(local_path))
     catch err do
       log(
         label="hls",
-        "HLS upload exception for #{remote_name}: #{err.kind}: #{err.message}",
+        "HLS upload read exception for #{remote_name}: #{err.kind}: #{
+          err.message
+        }",
         level=2
       )
       false
@@ -182,92 +141,15 @@ def hls_delete_file(remote_name) =
   end
 end
 
-def hls_retry_once(description, op) =
-  if
-    not op()
-  then
-    log(
-      label="hls",
-      "Retrying HLS #{description} once",
-      level=3
-    )
-
-    if
-      not op()
-    then
-      log(
-        label="hls",
-        "Giving up HLS #{description} after retry",
-        level=2
-      )
-    end
-  end
-end
-
-def hls_upload_with_retry(local_path) =
-  let remote_name = path.basename(local_path)
-  hls_retry_once(
-    "upload for #{remote_name}",
-    fun () -> hls_put_file(local_path, remote_name)
-  )
-end
-
-def hls_delete_with_retry(remote_name) =
-  hls_retry_once(
-    "delete for #{remote_name}",
-    fun () -> hls_delete_file(remote_name)
-  )
-end
-
-def hls_process_event(item) =
-  let remote_name = path.basename(item.path)
-  if
-    item.state == "deleted"
-  then
-    hls_delete_with_retry(remote_name)
-  elsif
-    item.state == "created" or item.state == "updated"
-  then
-    hls_upload_with_retry(item.path)
-  else
-    log(
-      label="hls",
-      "Ignoring unknown HLS file event #{item.state} for #{item.path}",
-      level=3
-    )
-  end
-end
-
-def hls_queue_pop() =
-  list.dcase(
-    hls_upload_queue(),
-    {null},
-    fun (item, rest) ->
-      begin
-        hls_upload_queue := rest
-        item
-      end
-  )
-end
-
-def hls_upload_worker() =
-  let item = hls_queue_pop()
-  if
-    null.defined(item)
-  then
-    hls_process_event(null.get(item))
-  end
-end
-
-def hls_local_files() =
+def hls_local_files(name_predicate) =
   if
     file.exists(HLS_DIR)
   then
     list.filter(
       fun (fname) ->
         begin
-          let name = path.basename(fname)
-          not file.is_directory(fname) and hls_is_sync_file_name(name)
+          not file.is_directory(fname)
+          and name_predicate(path.basename(fname))
         end,
       file.ls(absolute=true, sorted=true, HLS_DIR)
     )
@@ -276,25 +158,53 @@ def hls_local_files() =
   end
 end
 
-def hls_local_names() =
-  list.map(fun (fname) -> path.basename(fname), hls_local_files())
+def hls_local_segment_files() =
+  hls_local_files(hls_is_segment_name)
 end
 
-def hls_reconcile() =
-  log(
-    label="hls",
-    "Reconciling local HLS window with Bunny Edge Storage prefix #{STATION_ID}/",
-    level=3
-  )
+def hls_read_playlist_snapshot(local_path) =
+  try
+    {name=path.basename(local_path), content=file.contents(local_path)}
+  catch err do
+    log(
+      label="hls",
+      "Skipping HLS playlist snapshot for #{local_path}: #{err.kind}: #{
+        err.message
+      }",
+      level=2
+    )
+    null
+  end
+end
 
-  let local_names = hls_local_names()
+def hls_playlist_snapshots() =
+  list.filter_map(
+    hls_read_playlist_snapshot,
+    hls_local_files(hls_is_playlist_name)
+  )
+end
+
+def hls_playlist_segment_names(content) =
+  list.filter_map(
+    fun (line) ->
+      begin
+        let line = string.trim(line)
+        if
+          hls_is_segment_name(line)
+        then
+          path.basename(line)
+        else
+          null
+        end
+      end,
+    r/\r?\n/.split(content)
+  )
+end
+
+def hls_remote_listing() =
   try
     let response =
-      http.get(
-        timeout=10.0,
-        headers=hls_bunny_headers,
-        hls_remote_dir_url()
-      )
+      http.get(timeout=10.0, headers=hls_bunny_headers, hls_remote_dir_url)
 
     if
       hls_is_success(response.status_code)
@@ -302,21 +212,12 @@ def hls_reconcile() =
       let json.parse (remote_entries :
         [{"ObjectName" as object_name: string}]
       ) = response
-
-      list.iter(
-        fun ({object_name}) ->
-          begin
-            let remote_name = path.basename(object_name)
-            if
-              remote_name != ""
-              and remote_name != "."
-              and not list.mem(remote_name, local_names)
-            then
-              hls_delete_with_retry(remote_name)
-            end
-          end,
-        remote_entries
-      )
+      let names =
+        list.map(
+          fun ({object_name}) -> path.basename(object_name),
+          remote_entries
+        )
+      {ok=true, names=list.filter(hls_is_sync_file_name, names)}
     elsif
       response.status_code == 404
     then
@@ -326,26 +227,207 @@ def hls_reconcile() =
          will create it",
         level=3
       )
+      {ok=true, names=[]}
     else
       log(
         label="hls",
-        "HLS reconcile listing failed: HTTP #{response.status_code} #{
+        "HLS mirror listing failed: HTTP #{response.status_code} #{
           response.status_message
         }",
         level=2
       )
+      {ok=false, names=[]}
     end
   catch err do
     log(
       label="hls",
-      "HLS reconcile listing exception: #{err.kind}: #{err.message}",
+      "HLS mirror listing exception: #{err.kind}: #{err.message}",
       level=2
     )
+    {ok=false, names=[]}
   end
-
-  list.iter(hls_upload_with_retry, hls_local_files())
 end
 
+def hls_seed_remote_segments((seeded:ref), (synced_segments:ref)) =
+  if
+    not seeded()
+  then
+    let listing = hls_remote_listing()
+    if
+      listing.ok
+    then
+      let remote_segments = list.filter(hls_is_segment_name, listing.names)
+      synced_segments.set(hls_union(synced_segments(), remote_segments))
+      seeded.set(true)
+      log(
+        label="hls",
+        "Seeded HLS mirror state with #{list.length(remote_segments)} remote \
+         segment(s)",
+        level=3
+      )
+    end
+  end
+end
+
+def hls_upload_segments((synced_segments:ref), segment_files) =
+  list.iter(
+    fun (local_path) ->
+      begin
+        let remote_name = path.basename(local_path)
+        if
+          not list.mem(remote_name, synced_segments())
+        then
+          if
+            hls_put_file(local_path)
+          then
+            synced_segments.set(hls_add_unique(remote_name, synced_segments()))
+          end
+        end
+      end,
+    segment_files
+  )
+end
+
+def hls_required_segments_ready(snapshot, (synced_segments:ref)) =
+  let segment_names = hls_playlist_segment_names(snapshot.content)
+  list.for_all(
+    fun (segment_name) -> list.mem(segment_name, synced_segments()),
+    segment_names
+  )
+end
+
+def hls_upload_playlist_group(
+  (synced_playlists:ref),
+  (synced_segments:ref),
+  playlists
+) =
+  let ok = ref(true)
+  list.iter(
+    fun (snapshot) ->
+      begin
+        let previous = list.assoc.nullable(snapshot.name, synced_playlists())
+        let changed =
+          not null.defined(previous) or null.get(previous) != snapshot.content
+        if
+          changed
+        then
+          if
+            hls_required_segments_ready(snapshot, synced_segments)
+          then
+            if
+              hls_put_data(snapshot.name, snapshot.content)
+            then
+              synced_playlists.set(
+                hls_assoc_set(
+                  snapshot.name,
+                  snapshot.content,
+                  synced_playlists()
+                )
+              )
+            else
+              ok := false
+            end
+          else
+            log(
+              label="hls",
+              "Deferring HLS playlist upload for #{snapshot.name}; at least \
+               one referenced segment is not mirrored yet",
+              level=3
+            )
+            ok := false
+          end
+        end
+      end,
+    playlists
+  )
+  ok()
+end
+
+def hls_upload_playlists(
+  (synced_playlists:ref),
+  (synced_segments:ref),
+  playlists
+) =
+  let variant_playlists =
+    list.filter(fun (p) -> p.name != hls_main_playlist_name, playlists)
+  let main_playlists =
+    list.filter(fun (p) -> p.name == hls_main_playlist_name, playlists)
+  let variants_ok =
+    hls_upload_playlist_group(
+      synced_playlists,
+      synced_segments,
+      variant_playlists
+    )
+  if
+    variants_ok
+    and not list.is_empty(variant_playlists)
+    and not list.is_empty(main_playlists)
+  then
+    hls_upload_playlist_group(synced_playlists, synced_segments, main_playlists)
+  else
+    if
+      not list.is_empty(main_playlists)
+    then
+      log(
+        label="hls",
+        "Deferring HLS main playlist upload until variant playlists are ready",
+        level=3
+      )
+    end
+    false
+  end
+end
+
+def hls_delete_stale_segments((synced_segments:ref), local_segment_names) =
+  list.iter(
+    fun (remote_name) ->
+      begin
+        if
+          not list.mem(remote_name, local_segment_names)
+        then
+          if
+            hls_delete_file(remote_name)
+          then
+            synced_segments.set(
+              list.filter(fun (name) -> name != remote_name, synced_segments())
+            )
+          end
+        end
+      end,
+    synced_segments()
+  )
+end
+
+def hls_mirror_tick(
+  (seeded:ref),
+  (synced_segments:ref),
+  (synced_playlists:ref)
+) =
+  hls_seed_remote_segments(seeded, synced_segments)
+
+  # Snapshot playlists before listing segments, then upload that exact content
+  # after segment uploads. This preserves segment-before-playlist publication
+  # even if Liquidsoap writes a newer playlist while this tick is running.
+  let playlists = hls_playlist_snapshots()
+  let segment_files = hls_local_segment_files()
+  let local_segment_names =
+    list.map(fun (fname) -> path.basename(fname), segment_files)
+
+  hls_upload_segments(synced_segments, segment_files)
+
+  let playlists_ok =
+    not list.is_empty(playlists)
+    and hls_upload_playlists(synced_playlists, synced_segments, playlists)
+
+  if
+    playlists_ok
+  then
+    hls_delete_stale_segments(synced_segments, local_segment_names)
+  end
+end
+
+# Timestamped segment names are never reused, even if state.json is lost
+# across restarts, so Bunny CDN can cache .aac segments with a long TTL.
 def hls_segment_name(segment_metadata) =
   let ts = int_of_float(time())
   "#{segment_metadata.stream_name}_#{ts}_#{segment_metadata.position}.#{
@@ -355,17 +437,15 @@ end
 
 def output_hls_stream(audio_source) =
   if
-    hls_enabled()
+    HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
   then
     log(
       label="hls",
-      "HLS output enabled - writing #{HLS_SEGMENTS}x#{
-        HLS_SEGMENT_DURATION
-      }s to #{HLS_DIR}, uploading to #{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/",
+      "HLS output enabled - writing #{HLS_SEGMENTS}x#{HLS_SEGMENT_DURATION}s to #{
+        HLS_DIR
+      }, uploading to #{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/",
       level=3
     )
-
-    file.mkdir(parents=true, HLS_DIR)
 
     # Buffer provides clock isolation from the live program chain.
     let hls_source = mksafe(buffer(audio_source))
@@ -379,9 +459,9 @@ def output_hls_stream(audio_source) =
         aot = 'mpeg4_he_aac',
         transmux = 'adts'
       ).{
-        bandwidth=HLS_BITRATE_LOW * 1000 + 8000,
-        codecs="mp4a.40.5",
-        extname="aac"
+        bandwidth = HLS_BITRATE_LOW * 1000 + 8000,
+        codecs = "mp4a.40.5",
+        extname = "aac"
       }
 
     let aac_mid =
@@ -393,9 +473,9 @@ def output_hls_stream(audio_source) =
         aot = 'mpeg4_aac_lc',
         transmux = 'adts'
       ).{
-        bandwidth=HLS_BITRATE_MID * 1000 + 8000,
-        codecs="mp4a.40.2",
-        extname="aac"
+        bandwidth = HLS_BITRATE_MID * 1000 + 8000,
+        codecs = "mp4a.40.2",
+        extname = "aac"
       }
 
     let aac_high =
@@ -407,14 +487,14 @@ def output_hls_stream(audio_source) =
         aot = 'mpeg4_aac_lc',
         transmux = 'adts'
       ).{
-        bandwidth=HLS_BITRATE_HIGH * 1000 + 8000,
-        codecs="mp4a.40.2",
-        extname="aac"
+        bandwidth = HLS_BITRATE_HIGH * 1000 + 8000,
+        codecs = "mp4a.40.2",
+        extname = "aac"
       }
 
     let hls_output =
       output.file.hls(
-        playlist="live.m3u8",
+        playlist=hls_main_playlist_name,
         segment_duration=HLS_SEGMENT_DURATION,
         segments=HLS_SEGMENTS,
         segments_overhead=HLS_SEGMENTS_OVERHEAD,
@@ -425,14 +505,25 @@ def output_hls_stream(audio_source) =
         hls_source
       )
 
-    hls_output.on_file_change(synchronous=true, hls_upload_enqueue)
-    thread.run(fast=false, every=0.25, hls_upload_worker)
-    thread.run(fast=false, delay=5.0, hls_reconcile)
+    let hls_remote_seeded = ref(false)
+    let hls_synced_segments = ref([])
+    let hls_synced_playlists = ref([])
+    thread.run(
+      fast=false,
+      delay=1.0,
+      every=1.0,
+      fun () ->
+        hls_mirror_tick(
+          hls_remote_seeded,
+          hls_synced_segments,
+          hls_synced_playlists
+        )
+    )
   else
     log(
       label="hls",
-      "HLS output disabled - HLS_BUNNY_STORAGE_ZONE and/or \
-       HLS_BUNNY_ACCESS_KEY not configured",
+      "HLS output disabled - HLS_BUNNY_STORAGE_ZONE and/or HLS_BUNNY_ACCESS_KEY \
+       not configured",
       level=3
     )
   end

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -5,10 +5,11 @@ let hls_bunny_headers = [("AccessKey", HLS_BUNNY_ACCESS_KEY)]
 let hls_main_playlist_name = "live.m3u8"
 let hls_endpoint_trimmed = string.trim(HLS_BUNNY_ENDPOINT)
 let hls_endpoint_without_https =
-  string.residual(prefix="https://", hls_endpoint_trimmed) ?? hls_endpoint_trimmed
+  string.residual(prefix="https://", hls_endpoint_trimmed)
+    ?? hls_endpoint_trimmed
 let hls_endpoint_without_scheme =
-  string.residual(prefix="http://", hls_endpoint_without_https) ??
-    hls_endpoint_without_https
+  string.residual(prefix="http://", hls_endpoint_without_https)
+    ?? hls_endpoint_without_https
 let hls_endpoint_host =
   r/\/+$/.replace(fun (_) -> "", hls_endpoint_without_scheme)
 
@@ -148,8 +149,7 @@ def hls_local_files(name_predicate) =
     list.filter(
       fun (fname) ->
         begin
-          not file.is_directory(fname)
-          and name_predicate(path.basename(fname))
+          not file.is_directory(fname) and name_predicate(path.basename(fname))
         end,
       file.ls(absolute=true, sorted=true, HLS_DIR)
     )
@@ -164,7 +164,7 @@ end
 
 def hls_read_playlist_snapshot(local_path) =
   try
-    {name=path.basename(local_path), content=file.contents(local_path)}
+    {name = path.basename(local_path), content = file.contents(local_path)}
   catch err do
     log(
       label="hls",
@@ -189,13 +189,7 @@ def hls_playlist_segment_names(content) =
     fun (line) ->
       begin
         let line = string.trim(line)
-        if
-          hls_is_segment_name(line)
-        then
-          path.basename(line)
-        else
-          null
-        end
+        if hls_is_segment_name(line) then path.basename(line) else null end
       end,
     r/\r?\n/.split(content)
   )
@@ -226,17 +220,17 @@ def hls_remote_listing() =
           fun ({object_name}) -> path.basename(object_name),
           remote_entries
         )
-      {ok=true, names=list.filter(hls_is_sync_file_name, names)}
+      {ok = true, names = list.filter(hls_is_sync_file_name, names)}
     elsif
       response.status_code == 404
     then
       log(
         label="hls",
-        "Bunny HLS prefix #{STATION_ID}/ does not exist yet; local files \
-         will create it",
+        "Bunny HLS prefix #{STATION_ID}/ does not exist yet; local files will \
+         create it",
         level=3
       )
-      {ok=true, names=[]}
+      {ok = true, names = []}
     else
       log(
         label="hls",
@@ -245,7 +239,7 @@ def hls_remote_listing() =
         }",
         level=2
       )
-      {ok=false, names=[]}
+      {ok = false, names = []}
     end
   catch err do
     log(
@@ -253,7 +247,7 @@ def hls_remote_listing() =
       "HLS mirror listing exception: #{err.kind}: #{err.message}",
       level=2
     )
-    {ok=false, names=[]}
+    {ok = false, names = []}
   end
 end
 
@@ -339,8 +333,8 @@ def hls_upload_playlist_group(
           else
             log(
               label="hls",
-              "Deferring HLS playlist upload for #{snapshot.name}; at least \
-               one referenced segment is not mirrored yet",
+              "Deferring HLS playlist upload for #{snapshot.name}; at least one \
+               referenced segment is not mirrored yet",
               level=3
             )
             ok := false

--- a/conf/rucphen.liq
+++ b/conf/rucphen.liq
@@ -11,6 +11,7 @@
 %include "lib/50_processing.liq"
 %include "lib/60_output_icecast.liq"
 %include "lib/61_output_dab.liq"
+%include "lib/62_output_hls.liq"
 %include "lib/80_server.liq"
 %include "lib/90_radio.liq"
 
@@ -133,3 +134,6 @@ output_icecast_stream(
 
 # DAB+ output
 output_dab_stream(radio_processed)
+
+# HLS output
+output_hls_stream(radio_processed)

--- a/conf/zuidwest.liq
+++ b/conf/zuidwest.liq
@@ -11,6 +11,7 @@
 %include "lib/50_processing.liq"
 %include "lib/60_output_icecast.liq"
 %include "lib/61_output_dab.liq"
+%include "lib/62_output_hls.liq"
 %include "lib/80_server.liq"
 %include "lib/90_radio.liq"
 
@@ -79,3 +80,6 @@ output_icecast_stream(
 
 # DAB+ output
 output_dab_stream(radio)
+
+# HLS output
+output_hls_stream(radio)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./audio:/audio
       - ./stereotool:/var/cache/liquidsoap/
       - ./socket:/tmp/liquidsoap # Server socket
+      - ./hls:/hls
     environment:
       - TZ=Europe/Amsterdam
     env_file:


### PR DESCRIPTION
## Summary
- Add optional HLS output gated by `HLS_BUNNY_STORAGE_ZONE` and `HLS_BUNNY_ACCESS_KEY`.
- Add three ADTS AAC variants: 48 kbps HE-AACv1, 96 kbps AAC-LC, and 192 kbps AAC-LC.
- Mirror generated HLS playlists and segments to Bunny Edge Storage from Liquidsoap with a single recurrent mirror loop.
- Preserve segment-before-playlist publication by uploading segment files first, then uploading playlist content snapshots only when every referenced segment is known to be mirrored.
- Publish variant playlists before the main playlist, and protect segment cleanup with both local segment files and the playlist snapshots from the same mirror tick.
- Retry failed segment uploads, playlist uploads, and stale segment deletes on subsequent mirror ticks until the local HLS window converges.
- Wire HLS output into all station configs and document env vars, Bunny setup, player URL shape, validation, and troubleshooting.

## Liquidsoap validation notes
- Checked Liquidsoap v2.4.5 source before implementation.
- `output.file.hls` supports `playlist`, `segment_duration`, `segment_name`, `segments_overhead`, `segments`, `temp_dir`, and `persist_at`.
- `segment_name` receives `position`, `extname`, `duration`, `ticks`, and `stream_name`.
- HLS stream methods support `bandwidth`, `codecs`, `extname`, `id3`, `id3_version`, and `replay_id3`.
- `on_file_change` fires after atomic rename, before playlist writes. The PR no longer uses it for mirroring because asynchronous callback tasks can run out of order, and a shared `.liq` queue would require non-atomic read-modify-write operations.
- `thread.run(every=...)` reschedules after the handler returns, so the mirror loop has a single state owner and no overlapping ticks.

## Verification
- `savonet/liquidsoap:v2.4.5 liquidsoap -c conf/*.liq` with HLS disabled.
- `savonet/liquidsoap:v2.4.5 liquidsoap -c conf/*.liq` with HLS enabled.
- Runtime HLS smoke test produced all three variant playlists and AAC segments; with an unreachable Bunny endpoint, segment uploads were retried and playlist uploads were deferred while referenced segments were not mirrored.
- `docker compose config --quiet` using a temporary `.env` copied from `.env.example`.
- `shellcheck` over repository shell scripts.
- `git diff --check`

## Notes
- Existing Liquidsoap warnings about top-level `id` shadowing in `conf/lib/30_silence.liq` and `conf/lib/41_source_studio.liq` are unchanged.
- The mirror loop intentionally prefers consistency over freshness: if a segment cannot be uploaded, it keeps publishing the previous good playlist rather than publishing a playlist with a segment 404.
- Runtime cleanup removes stale segments. If HLS variant playlist names are changed, clean the station prefix in Bunny Edge Storage once to remove old playlist files.
- Public Bunny CDN validation was not run because the repository does not include real Bunny storage credentials.
