### PR TITLE
feat: shared stream metadata endpoint with timed ID3 in HLS

### DIFF
--- a/.env.bredanu.example
+++ b/.env.bredanu.example
@@ -48,7 +48,7 @@ ICECAST_SOURCE_PASSWORD=hackme
 # [REQUIRED] SRT encryption passphrase
 SRT_PASSPHRASE=foxtrot-uniform-charlie-kilo
 
-# [OPTIONAL] SRT listening ports
+# [OPTIONAL] SRT bind address and listening ports
 # SRT_BIND=0.0.0.0                # Default: all host interfaces
 # SRT_PORT_PRIMARY=8888          # Default: 8888
 # SRT_PORT_SECONDARY=9999        # Default: 9999

--- a/.env.bredanu.example
+++ b/.env.bredanu.example
@@ -49,6 +49,7 @@ ICECAST_SOURCE_PASSWORD=hackme
 SRT_PASSPHRASE=foxtrot-uniform-charlie-kilo
 
 # [OPTIONAL] SRT listening ports
+# SRT_BIND=0.0.0.0                # Default: all host interfaces
 # SRT_PORT_PRIMARY=8888          # Default: 8888
 # SRT_PORT_SECONDARY=9999        # Default: 9999
 
@@ -73,6 +74,7 @@ AUDIO_VALID_SECONDS=15.0       # Default: 15.0
 STEREOTOOL_LICENSE=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # [OPTIONAL] StereoTool web interface
+# STEREOTOOL_WEB_BIND=0.0.0.0    # Default: all host interfaces
 # STEREOTOOL_WEB_PORT=8080       # Default: 8080
 
 # ====================
@@ -116,9 +118,13 @@ DME_MOUNT_POINT=/xxxx
 # HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 # HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
 # HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
-# HLS_METADATA_BIND=127.0.0.1
-# HLS_METADATA_PORT=7000
-# HLS_METADATA_BEARER_TOKEN=<long-random-token>
+
+# ====================
+# STREAM METADATA
+# ====================
+# STREAM_METADATA_BIND=127.0.0.1
+# STREAM_METADATA_PORT=7000
+# STREAM_METADATA_BEARER_TOKEN=<long-random-token>
 
 # ====================
 # DOCKER CONFIGURATION

--- a/.env.bredanu.example
+++ b/.env.bredanu.example
@@ -116,6 +116,9 @@ DME_MOUNT_POINT=/xxxx
 # HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 # HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
 # HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+# HLS_METADATA_BIND=127.0.0.1
+# HLS_METADATA_PORT=7000
+# HLS_METADATA_BEARER_TOKEN=<long-random-token>
 
 # ====================
 # DOCKER CONFIGURATION

--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ ICECAST_SOURCE_PASSWORD=hackme
 # Use a strong passphrase to prevent unauthorized access
 SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 
-# [OPTIONAL] SRT listening ports (must be open in firewall)
+# [OPTIONAL] SRT bind address and listening ports (ports must be open in firewall)
 # SRT_BIND=0.0.0.0                # Default: all host interfaces
 # SRT_PORT_PRIMARY=8888          # Default: 8888 (main studio)
 # SRT_PORT_SECONDARY=9999        # Default: 9999 (backup studio)
@@ -95,7 +95,7 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # [OPTIONAL] License key - leave commented to disable StereoTool
 # STEREOTOOL_LICENSE=
 
-# [OPTIONAL] Web interface port for StereoTool configuration
+# [OPTIONAL] Web interface for StereoTool configuration
 # STEREOTOOL_WEB_BIND=0.0.0.0    # Default: all host interfaces
 # STEREOTOOL_WEB_PORT=8080       # Default: 8080
 

--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,12 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # HLS_SEGMENTS=10
 # HLS_SEGMENTS_OVERHEAD=5
 
+# [OPTIONAL] Authenticated endpoint for timed ID3 metadata from zwfm-metadata
+# Endpoint is disabled until a bearer token is configured
+# HLS_METADATA_BIND=127.0.0.1
+# HLS_METADATA_PORT=7000
+# HLS_METADATA_BEARER_TOKEN=replace-with-a-long-random-token
+
 # ====================
 # DUTCH MEDIA EXCHANGE (DME)
 # ====================

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,7 @@ ICECAST_SOURCE_PASSWORD=hackme
 SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 
 # [OPTIONAL] SRT listening ports (must be open in firewall)
+# SRT_BIND=0.0.0.0                # Default: all host interfaces
 # SRT_PORT_PRIMARY=8888          # Default: 8888 (main studio)
 # SRT_PORT_SECONDARY=9999        # Default: 9999 (backup studio)
 
@@ -88,6 +89,7 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # STEREOTOOL_LICENSE=
 
 # [OPTIONAL] Web interface port for StereoTool configuration
+# STEREOTOOL_WEB_BIND=0.0.0.0    # Default: all host interfaces
 # STEREOTOOL_WEB_PORT=8080       # Default: 8080
 
 # ====================
@@ -135,11 +137,14 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # HLS_SEGMENTS=10
 # HLS_SEGMENTS_OVERHEAD=5
 
-# [OPTIONAL] Authenticated endpoint for timed ID3 metadata from zwfm-metadata
+# ====================
+# STREAM METADATA
+# ====================
+# [OPTIONAL] Authenticated endpoint for an external metadata producer
 # Endpoint is disabled until a bearer token is configured
-# HLS_METADATA_BIND=127.0.0.1
-# HLS_METADATA_PORT=7000
-# HLS_METADATA_BEARER_TOKEN=replace-with-a-long-random-token
+# STREAM_METADATA_BIND=127.0.0.1
+# STREAM_METADATA_PORT=7000
+# STREAM_METADATA_BEARER_TOKEN=replace-with-a-long-random-token
 
 # ====================
 # DUTCH MEDIA EXCHANGE (DME)

--- a/.env.rucphen.example
+++ b/.env.rucphen.example
@@ -17,6 +17,7 @@ ICECAST_MOUNT_BASE=radiorucphen
 # SRT STUDIO INPUTS
 # ====================
 SRT_PASSPHRASE=foxtrot-uniform-charlie-kilo
+# SRT_BIND=0.0.0.0
 
 # ====================
 # AUDIO FALLBACK & SILENCE DETECTION
@@ -27,6 +28,7 @@ EMERGENCY_AUDIO_PATH=/audio/fallback.mp3
 # STEREOTOOL AUDIO PROCESSING
 # ====================
 STEREOTOOL_LICENSE=<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>
+# STEREOTOOL_WEB_BIND=0.0.0.0
 
 # ====================
 # DUTCH MEDIA EXCHANGE (DME)
@@ -56,6 +58,10 @@ DAB_METADATA_SOCKET=padenc.sock
 # HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 # HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
 # HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
-# HLS_METADATA_BIND=127.0.0.1
-# HLS_METADATA_PORT=7000
-# HLS_METADATA_BEARER_TOKEN=<long-random-token>
+
+# ====================
+# STREAM METADATA
+# ====================
+# STREAM_METADATA_BIND=127.0.0.1
+# STREAM_METADATA_PORT=7000
+# STREAM_METADATA_BEARER_TOKEN=<long-random-token>

--- a/.env.rucphen.example
+++ b/.env.rucphen.example
@@ -56,3 +56,6 @@ DAB_METADATA_SOCKET=padenc.sock
 # HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 # HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
 # HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+# HLS_METADATA_BIND=127.0.0.1
+# HLS_METADATA_PORT=7000
+# HLS_METADATA_BEARER_TOKEN=<long-random-token>

--- a/.env.zuidwest.example
+++ b/.env.zuidwest.example
@@ -44,3 +44,6 @@ DAB_METADATA_SOCKET=padenc.sock
 # HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 # HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
 # HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+# HLS_METADATA_BIND=127.0.0.1
+# HLS_METADATA_PORT=7000
+# HLS_METADATA_BEARER_TOKEN=<long-random-token>

--- a/.env.zuidwest.example
+++ b/.env.zuidwest.example
@@ -18,6 +18,7 @@ ICECAST_SOURCE_PASSWORD=hackme
 # SRT STUDIO INPUTS
 # ====================
 SRT_PASSPHRASE=foxtrot-uniform-charlie-kilo
+# SRT_BIND=0.0.0.0
 
 # ====================
 # AUDIO FALLBACK & SILENCE DETECTION
@@ -29,6 +30,7 @@ SILENCE_SWITCH_SECONDS=10.0
 # STEREOTOOL AUDIO PROCESSING
 # ====================
 STEREOTOOL_LICENSE=<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>
+# STEREOTOOL_WEB_BIND=0.0.0.0
 
 # ====================
 # DAB+ DIGITAL RADIO
@@ -44,6 +46,10 @@ DAB_METADATA_SOCKET=padenc.sock
 # HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 # HLS_BUNNY_ACCESS_KEY=<bunny-edge-storage-read-write-password>
 # HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
-# HLS_METADATA_BIND=127.0.0.1
-# HLS_METADATA_PORT=7000
-# HLS_METADATA_BEARER_TOKEN=<long-random-token>
+
+# ====================
+# STREAM METADATA
+# ====================
+# STREAM_METADATA_BIND=127.0.0.1
+# STREAM_METADATA_PORT=7000
+# STREAM_METADATA_BEARER_TOKEN=<long-random-token>

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ As an optional integration, configure one URL output in [zwfm-metadata](https://
 
 The URL template fields are URL-encoded by `zwfm-metadata`. When using that integration, this single output can replace direct Icecast metadata outputs for mounts produced by this Liquidsoap instance.
 
-Keep the endpoint on a private network. The Compose configuration binds it to `127.0.0.1` by default. When both applications run in containers, attach them to the same Docker network and use the `liquidsoap` service name. For a metadata service on another host, set `STREAM_METADATA_BIND=0.0.0.0` and restrict the port with a firewall to that host.
+Keep the endpoint on a private network. The Compose configuration binds it to `127.0.0.1` by default. When both applications run in containers, attach them to the same Docker network and use the `liquidsoap` service name. For a metadata service on another host, use a trusted private or VPN network, or place the endpoint behind a TLS reverse proxy. If binding to `0.0.0.0`, restrict the port with a firewall to that host and never expose the raw HTTP endpoint to an untrusted network.
 
 For HLS playback, players must consume timed ID3 to display the values. For example, hls.js emits `FRAG_PARSING_METADATA`; native Apple and Android HLS players expose equivalent timed metadata callbacks.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ This table lists ALL environment variables used in the system. Variables without
 | `HLS_SEGMENT_DURATION`            | HLS segment duration in seconds                  | `4.0`                        | `4.0`                                                           | `conf/lib/00_settings.liq`             | All             |
 | `HLS_SEGMENTS`                    | Segments per live playlist                       | `10`                         | `10`                                                            | `conf/lib/00_settings.liq`             | All             |
 | `HLS_SEGMENTS_OVERHEAD`           | Extra old segments retained locally              | `5`                          | `5`                                                             | `conf/lib/00_settings.liq`             | All             |
+| `HLS_METADATA_BIND`               | Host address for the metadata API                 | `127.0.0.1`                  | `0.0.0.0`                                                       | `docker-compose.yml`                    | All             |
+| `HLS_METADATA_PORT`               | Timed metadata API port                           | `7000`                       | `7000`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `HLS_METADATA_BEARER_TOKEN`       | Enables and protects the timed metadata API       | _(none)_                     | `long-random-token`                                             | `conf/lib/00_settings.liq`             | All             |
 | **DME Configuration**             |
 | `DME_PRIMARY_HOST`                | Primary DME server                               | _(required)_                 | `ingest1.dme.nl`                                                | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
 | `DME_PRIMARY_PORT`                | Primary DME port                                 | _(required)_                 | `8010`                                                          | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
@@ -352,9 +355,49 @@ Set both Bunny variables to enable HLS:
 HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 HLS_BUNNY_ACCESS_KEY=storage-zone-read-write-password
 HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
+HLS_METADATA_PORT=7000
+HLS_METADATA_BEARER_TOKEN=replace-with-a-long-random-token
 ```
 
 The AccessKey is the storage zone read/write password. Use a dedicated Edge Storage zone for HLS so this credential is scoped to live-stream objects only.
+
+### Timed metadata
+
+When `HLS_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts now-playing
+updates at `GET /metadata/hls` on `HLS_METADATA_PORT`. The update is inserted
+into the HLS branch and encoded as timed ID3 in every MPEG-TS variant. Because
+the metadata travels in the media segments, it remains synchronized with the
+audio through the HLS and CDN buffers.
+
+Configure a URL output in
+[zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) and use the same
+input priority, filters, and delay as the corresponding Icecast output:
+
+```json
+{
+  "type": "url",
+  "name": "hls-timed-metadata",
+  "inputs": ["radio-live", "radio-automation", "default-text"],
+  "formatters": [],
+  "settings": {
+    "delay": 0,
+    "url": "http://liquidsoap:7000/metadata/hls?title={{.title}}&artist={{.artist}}",
+    "method": "GET",
+    "bearerToken": "replace-with-the-same-long-random-token"
+  }
+}
+```
+
+The URL template fields are URL-encoded by `zwfm-metadata`. Keep the endpoint
+on a private network. The Compose configuration binds it to `127.0.0.1` by
+default. When both applications run in containers, attach them to the same
+Docker network and use the `liquidsoap` service name. For a metadata service on
+another host, set `HLS_METADATA_BIND=0.0.0.0` and restrict the port with a
+firewall to that host.
+
+Players must consume timed ID3 to display the values. For example, hls.js emits
+`FRAG_PARSING_METADATA`; native Apple and Android HLS players expose equivalent
+timed metadata callbacks.
 
 ### Bunny Setup
 

--- a/README.md
+++ b/README.md
@@ -131,11 +131,13 @@ This table lists ALL environment variables used in the system. Variables without
 | `ICECAST_BITRATE_AAC_HIGH`        | High AAC bitrate (kbps)                          | `576`                        | `320`                                                           | `conf/lib/00_settings.liq`             | All             |
 | **SRT Studio Inputs**             |
 | `SRT_PASSPHRASE`                  | SRT encryption passphrase                        | _(required)_                 | `alpha-bravo-charlie-delta`                                     | `conf/lib/00_settings.liq`             | All             |
-| `SRT_PORT_PRIMARY`                | Primary SRT listening port                       | `8888`                       | `8888`                                                          | `conf/lib/00_settings.liq`             | All             |
-| `SRT_PORT_SECONDARY`              | Secondary SRT listening port                     | `9999`                       | `9999`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `SRT_BIND`                        | Host address for both SRT inputs                  | `0.0.0.0`                    | `192.0.2.10`                                                    | `docker-compose.yml`                    | All             |
+| `SRT_PORT_PRIMARY`                | Primary SRT listening port                       | `8888`                       | `8888`                                                          | Liquidsoap and Compose                  | All             |
+| `SRT_PORT_SECONDARY`              | Secondary SRT listening port                     | `9999`                       | `9999`                                                          | Liquidsoap and Compose                  | All             |
 | **Audio Processing**              |
 | `STEREOTOOL_LICENSE`              | StereoTool license key                           | _(none)_                     | `ABC123DEF456...`                                               | `conf/lib/00_settings.liq`             | All             |
-| `STEREOTOOL_WEB_PORT`             | StereoTool web interface port                    | `8080`                       | `8080`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `STEREOTOOL_WEB_BIND`             | Host address for the StereoTool web interface     | `0.0.0.0`                    | `127.0.0.1`                                                     | `docker-compose.yml`                    | All             |
+| `STEREOTOOL_WEB_PORT`             | StereoTool web interface host port                | `8080`                       | `8080`                                                          | `docker-compose.yml`                    | All             |
 | **Fallback & Control**            |
 | `SERVER_SOCKET_ENABLED`           | Enable Unix socket for runtime control           | `true`                       | `true`                                                          | `conf/lib/90_server.liq`               | All             |
 | `SERVER_SOCKET_PATH`              | Unix socket file path                            | `/tmp/liquidsoap/liquidsoap.sock` | `/tmp/liquidsoap/liquidsoap.sock`                          | `conf/lib/90_server.liq`               | All             |
@@ -158,9 +160,10 @@ This table lists ALL environment variables used in the system. Variables without
 | `HLS_SEGMENT_DURATION`            | HLS segment duration in seconds                  | `4.0`                        | `4.0`                                                           | `conf/lib/00_settings.liq`             | All             |
 | `HLS_SEGMENTS`                    | Segments per live playlist                       | `10`                         | `10`                                                            | `conf/lib/00_settings.liq`             | All             |
 | `HLS_SEGMENTS_OVERHEAD`           | Extra old segments retained locally              | `5`                          | `5`                                                             | `conf/lib/00_settings.liq`             | All             |
-| `HLS_METADATA_BIND`               | Host address for the metadata API                 | `127.0.0.1`                  | `0.0.0.0`                                                       | `docker-compose.yml`                    | All             |
-| `HLS_METADATA_PORT`               | Timed metadata API port                           | `7000`                       | `7000`                                                          | `conf/lib/00_settings.liq`             | All             |
-| `HLS_METADATA_BEARER_TOKEN`       | Enables and protects the timed metadata API       | _(none)_                     | `long-random-token`                                             | `conf/lib/00_settings.liq`             | All             |
+| **Stream Metadata (Optional)**    |
+| `STREAM_METADATA_BIND`            | Host address for the metadata API                 | `127.0.0.1`                  | `0.0.0.0`                                                       | `docker-compose.yml`                    | All             |
+| `STREAM_METADATA_PORT`            | Shared stream metadata API port                   | `7000`                       | `7000`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `STREAM_METADATA_BEARER_TOKEN`    | Enables and protects the stream metadata API      | _(none)_                     | `long-random-token`                                             | `conf/lib/00_settings.liq`             | All             |
 | **DME Configuration**             |
 | `DME_PRIMARY_HOST`                | Primary DME server                               | _(required)_                 | `ingest1.dme.nl`                                                | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
 | `DME_PRIMARY_PORT`                | Primary DME port                                 | _(required)_                 | `8010`                                                          | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
@@ -203,6 +206,10 @@ docker compose down
 ### StereoTool GUI
 
 When StereoTool is enabled (by providing a `STEREOTOOL_LICENSE` in the `.env` file), access the web interface at: `http://localhost:8080`
+
+Set `STEREOTOOL_WEB_BIND=127.0.0.1` to restrict the interface to the local
+host, or bind it to a specific host address. The default remains `0.0.0.0` for
+backward compatibility.
 
 ### Audio Processing with StereoTool
 
@@ -300,8 +307,13 @@ For production use, consider using [rpi-audio-encoder](https://github.com/oszuid
 
 The SRT listening ports can be customized via environment variables:
 
+- `SRT_BIND`: Host address for both published SRT ports (default: 0.0.0.0)
 - `SRT_PORT_PRIMARY`: Primary studio input port (default: 8888)
 - `SRT_PORT_SECONDARY`: Secondary studio input port (default: 9999)
+
+Use a specific address for `SRT_BIND` when studio traffic should only enter on
+one host interface. This controls Docker's published host address; Liquidsoap
+continues to listen on the corresponding container ports.
 
 ## DAB+ Digital Radio Broadcasting
 
@@ -333,6 +345,68 @@ DAB_EDI_DESTINATIONS=tcp://primary.example.com:9001,tcp://backup.example.com:900
 
 PAD allows sending metadata like song titles and station logos alongside the audio. Recommendation to use as small of a METADATA_SIZE as possible. 8 bytes is enough to transmit a logo in a couple of seconds (ofcourse, how smaller the filesize the faster the logo will transmit). If you're using artwork, you might need to consider using a bigger METADATA_SIZE.
 
+## Shared Stream Metadata
+
+When `STREAM_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts
+now-playing updates at `GET /metadata` on `STREAM_METADATA_PORT`. Metadata is
+inserted into the main radio source before processing and the output fan-out.
+One update therefore reaches every compatible Liquidsoap stream output:
+
+- Icecast MP3 and AAC mounts
+- DME Icecast mounts for Radio Rucphen and BredaNu
+- HLS variants, encoded as timed ID3 in each MPEG-TS segment
+
+DAB+ PAD and StereoTool/RDS remain protocol-specific metadata outputs. DAB uses
+the configured PAD socket, while StereoTool metadata is sent through its API;
+neither is derived from Liquidsoap source metadata.
+
+Any metadata producer can call the endpoint. For example:
+
+```bash
+curl --get http://127.0.0.1:7000/metadata \
+  --header "Authorization: Bearer ${STREAM_METADATA_BEARER_TOKEN}" \
+  --data-urlencode "title=Song title" \
+  --data-urlencode "artist=Artist name"
+```
+
+The producer can be a playout or automation system, studio application,
+webhook, or script. The only requirements are a non-empty `title`, an optional
+`artist`, and the configured bearer token.
+
+As an optional integration, configure one URL output in
+[zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired
+input priority, filters, and delay:
+
+```json
+{
+  "type": "url",
+  "name": "liquidsoap-stream-metadata",
+  "inputs": ["radio-live", "radio-automation", "default-text"],
+  "formatters": [],
+  "settings": {
+    "delay": 0,
+    "url": "http://liquidsoap:7000/metadata?title={{.title}}&artist={{.artist}}",
+    "method": "GET",
+    "bearerToken": "replace-with-the-same-long-random-token"
+  }
+}
+```
+
+The URL template fields are URL-encoded by `zwfm-metadata`. When using that
+integration, this single output can replace direct Icecast metadata outputs for
+mounts produced by this Liquidsoap instance. Keep separate outputs for DAB PAD,
+StereoTool/RDS, and any streams produced elsewhere.
+
+Keep the endpoint on a private network. The Compose configuration binds it to
+`127.0.0.1` by default. When both applications run in containers, attach them
+to the same Docker network and use the `liquidsoap` service name. For a metadata
+service on another host, set `STREAM_METADATA_BIND=0.0.0.0` and restrict the
+port with a firewall to that host.
+
+For HLS playback, players must consume timed ID3 to display the values. For
+example, hls.js emits `FRAG_PARSING_METADATA`; native Apple and Android HLS
+players expose equivalent timed metadata callbacks.
+
 ## HLS Output via Bunny CDN
 
 The system supports optional audio-only HLS output. Liquidsoap writes a local HLS live window to `/hls`, then mirrors it to Bunny Edge Storage with native `http.put` and `http.delete` calls. No sidecar uploader or extra Docker image dependency is required.
@@ -355,49 +429,9 @@ Set both Bunny variables to enable HLS:
 HLS_BUNNY_STORAGE_ZONE=zwfm-hls
 HLS_BUNNY_ACCESS_KEY=storage-zone-read-write-password
 HLS_BUNNY_ENDPOINT=storage.bunnycdn.com
-HLS_METADATA_PORT=7000
-HLS_METADATA_BEARER_TOKEN=replace-with-a-long-random-token
 ```
 
 The AccessKey is the storage zone read/write password. Use a dedicated Edge Storage zone for HLS so this credential is scoped to live-stream objects only.
-
-### Timed metadata
-
-When `HLS_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts now-playing
-updates at `GET /metadata/hls` on `HLS_METADATA_PORT`. The update is inserted
-into the HLS branch and encoded as timed ID3 in every MPEG-TS variant. Because
-the metadata travels in the media segments, it remains synchronized with the
-audio through the HLS and CDN buffers.
-
-Configure a URL output in
-[zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) and use the same
-input priority, filters, and delay as the corresponding Icecast output:
-
-```json
-{
-  "type": "url",
-  "name": "hls-timed-metadata",
-  "inputs": ["radio-live", "radio-automation", "default-text"],
-  "formatters": [],
-  "settings": {
-    "delay": 0,
-    "url": "http://liquidsoap:7000/metadata/hls?title={{.title}}&artist={{.artist}}",
-    "method": "GET",
-    "bearerToken": "replace-with-the-same-long-random-token"
-  }
-}
-```
-
-The URL template fields are URL-encoded by `zwfm-metadata`. Keep the endpoint
-on a private network. The Compose configuration binds it to `127.0.0.1` by
-default. When both applications run in containers, attach them to the same
-Docker network and use the `liquidsoap` service name. For a metadata service on
-another host, set `HLS_METADATA_BIND=0.0.0.0` and restrict the port with a
-firewall to that host.
-
-Players must consume timed ID3 to display the values. For example, hls.js emits
-`FRAG_PARSING_METADATA`; native Apple and Android HLS players expose equivalent
-timed metadata callbacks.
 
 ### Bunny Setup
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This table lists ALL environment variables used in the system. Variables without
 | `HLS_SEGMENTS_OVERHEAD`           | Extra old segments retained locally              | `5`                          | `5`                                                             | `conf/lib/00_settings.liq`             | All             |
 | **Stream Metadata (Optional)**    |
 | `STREAM_METADATA_BIND`            | Host address for the metadata API                 | `127.0.0.1`                  | `0.0.0.0`                                                       | `docker-compose.yml`                    | All             |
-| `STREAM_METADATA_PORT`            | Shared stream metadata API port                   | `7000`                       | `7000`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `STREAM_METADATA_PORT`            | Shared stream metadata API port                   | `7000`                       | `7000`                                                          | Liquidsoap and Compose                  | All             |
 | `STREAM_METADATA_BEARER_TOKEN`    | Enables and protects the stream metadata API      | _(none)_                     | `long-random-token`                                             | `conf/lib/00_settings.liq`             | All             |
 | **DME Configuration**             |
 | `DME_PRIMARY_HOST`                | Primary DME server                               | _(required)_                 | `ingest1.dme.nl`                                                | `conf/rucphen.liq`, `conf/bredanu.liq` | Rucphen/BredaNu |
@@ -211,9 +211,7 @@ docker compose down
 
 When StereoTool is enabled (by providing a `STEREOTOOL_LICENSE` in the `.env` file), access the web interface at: `http://localhost:8080`
 
-Set `STEREOTOOL_WEB_BIND=127.0.0.1` to restrict the interface to the local
-host, or bind it to a specific host address. The default remains `0.0.0.0` for
-backward compatibility.
+Set `STEREOTOOL_WEB_BIND=127.0.0.1` to restrict the interface to the local host, or bind it to a specific host address. The default remains `0.0.0.0` for backward compatibility.
 
 ### Audio Processing with StereoTool
 
@@ -317,9 +315,7 @@ The SRT listening ports can be customized via environment variables:
 - `SRT_PORT_PRIMARY`: Primary studio input port (default: 8888)
 - `SRT_PORT_SECONDARY`: Secondary studio input port (default: 9999)
 
-Use a specific address for `SRT_BIND` when studio traffic should only enter on
-one host interface. This controls Docker's published host address; Liquidsoap
-continues to listen on the corresponding container ports.
+Use a specific address for `SRT_BIND` when studio traffic should only enter on one host interface. This controls Docker's published host address; Liquidsoap continues to listen on the corresponding container ports.
 
 ## DAB+ Digital Radio Broadcasting
 
@@ -353,18 +349,13 @@ PAD allows sending metadata like song titles and station logos alongside the aud
 
 ## Shared Stream Metadata
 
-When `STREAM_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts
-now-playing updates at `GET /metadata` on `STREAM_METADATA_PORT`. Metadata is
-inserted into the main radio source before processing and the output fan-out.
-One update therefore reaches every compatible Liquidsoap stream output:
+When `STREAM_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts now-playing updates at `GET /metadata` on `STREAM_METADATA_PORT`. Metadata is inserted into the main radio source before processing and the output fan-out. One update therefore reaches every compatible Liquidsoap stream output:
 
 - Icecast MP3 and AAC mounts
 - DME Icecast mounts for Radio Rucphen and BredaNu
 - HLS variants, encoded as timed ID3 in each MPEG-TS segment
 
-DAB+ PAD and StereoTool/RDS remain protocol-specific metadata outputs. DAB uses
-the configured PAD socket, while StereoTool metadata is sent through its API;
-neither is derived from Liquidsoap source metadata.
+DAB+ PAD and StereoTool/RDS remain protocol-specific metadata outputs. DAB uses the configured PAD socket, while StereoTool metadata is sent through its API; neither is derived from Liquidsoap source metadata.
 
 Any metadata producer can call the endpoint. For example:
 
@@ -375,13 +366,11 @@ curl --get http://127.0.0.1:7000/metadata \
   --data-urlencode "artist=Artist name"
 ```
 
-The producer can be a playout or automation system, studio application,
-webhook, or script. The only requirements are a non-empty `title`, an optional
-`artist`, and the configured bearer token.
+The producer can be a playout or automation system, studio application, webhook, or script. The only requirements are a non-empty `title`, an optional `artist`, and the configured bearer token.
 
-As an optional integration, configure one URL output in
-[zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired
-input priority, filters, and delay:
+The endpoint returns `204 No Content` on success, `400 Bad Request` when `title` is missing, and `401 Unauthorized` when the bearer token is missing or wrong. Omitting `artist` sends a title-only update. A connection reset on the metadata port means the endpoint is disabled because no bearer token is configured.
+
+As an optional integration, configure one URL output in [zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired input priority, filters, and delay:
 
 ```json
 {
@@ -398,20 +387,11 @@ input priority, filters, and delay:
 }
 ```
 
-The URL template fields are URL-encoded by `zwfm-metadata`. When using that
-integration, this single output can replace direct Icecast metadata outputs for
-mounts produced by this Liquidsoap instance. Keep separate outputs for DAB PAD,
-StereoTool/RDS, and any streams produced elsewhere.
+The URL template fields are URL-encoded by `zwfm-metadata`. When using that integration, this single output can replace direct Icecast metadata outputs for mounts produced by this Liquidsoap instance. Keep separate outputs for DAB PAD, StereoTool/RDS, and any streams produced elsewhere.
 
-Keep the endpoint on a private network. The Compose configuration binds it to
-`127.0.0.1` by default. When both applications run in containers, attach them
-to the same Docker network and use the `liquidsoap` service name. For a metadata
-service on another host, set `STREAM_METADATA_BIND=0.0.0.0` and restrict the
-port with a firewall to that host.
+Keep the endpoint on a private network. The Compose configuration binds it to `127.0.0.1` by default. When both applications run in containers, attach them to the same Docker network and use the `liquidsoap` service name. For a metadata service on another host, set `STREAM_METADATA_BIND=0.0.0.0` and restrict the port with a firewall to that host.
 
-For HLS playback, players must consume timed ID3 to display the values. For
-example, hls.js emits `FRAG_PARSING_METADATA`; native Apple and Android HLS
-players expose equivalent timed metadata callbacks.
+For HLS playback, players must consume timed ID3 to display the values. For example, hls.js emits `FRAG_PARSING_METADATA`; native Apple and Android HLS players expose equivalent timed metadata callbacks.
 
 ## HLS Output via Bunny CDN
 

--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ curl --get http://127.0.0.1:7000/metadata \
   --data-urlencode "artist=Artist name"
 ```
 
-The producer can be a playout or automation system, studio application, webhook, or script. The only requirements are a non-empty `title`, an optional `artist`, and the configured bearer token.
+The only requirements are a non-empty `title`, an optional `artist`, and the configured bearer token.
 
-The endpoint returns `204 No Content` on success, `400 Bad Request` when `title` is missing, and `401 Unauthorized` when the bearer token is missing or wrong. Omitting `artist` sends a title-only update. A connection reset on the metadata port means the endpoint is disabled because no bearer token is configured.
+The endpoint returns `204 No Content` on success, `400 Bad Request` when `title` is missing, and `401 Unauthorized` when the bearer token is missing or wrong. Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
 
 As an optional integration, configure one URL output in [zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired input priority, filters, and delay:
 
@@ -387,7 +387,7 @@ As an optional integration, configure one URL output in [zwfm-metadata](https://
 }
 ```
 
-The URL template fields are URL-encoded by `zwfm-metadata`. When using that integration, this single output can replace direct Icecast metadata outputs for mounts produced by this Liquidsoap instance. Keep separate outputs for DAB PAD, StereoTool/RDS, and any streams produced elsewhere.
+The URL template fields are URL-encoded by `zwfm-metadata`. When using that integration, this single output can replace direct Icecast metadata outputs for mounts produced by this Liquidsoap instance.
 
 Keep the endpoint on a private network. The Compose configuration binds it to `127.0.0.1` by default. When both applications run in containers, attach them to the same Docker network and use the `liquidsoap` service name. For a metadata service on another host, set `STREAM_METADATA_BIND=0.0.0.0` and restrict the port with a firewall to that host.
 

--- a/conf/bredanu.liq
+++ b/conf/bredanu.liq
@@ -36,12 +36,11 @@ let studio_b = create_studio_input(id="studio_b", port=SRT_PORT_SECONDARY)
 # Build radio source with fallback chain, force support, and server commands
 let radio =
   create_radio(
-    sources=
-      [
-        ("studio_a", studio_a),
-        ("studio_b", studio_b),
-        ("fallback", emergency_fallback)
-      ]
+    sources=[
+      ("studio_a", studio_a),
+      ("studio_b", studio_b),
+      ("fallback", emergency_fallback)
+    ]
   )
 
 # Create processed audio source
@@ -49,68 +48,61 @@ let radio_processed = create_processed_audio(radio)
 
 # Output streams - BredaNu uses processed audio
 output_icecast_stream(
-  format=
-    %ffmpeg(
-      format = "mp3",
-      %audio(
-        codec = "libmp3lame",
-        b = "#{ICECAST_BITRATE_MP3}k",
-        ar = 48000,
-        ac = 2
-      )
-    ),
-  description=
-    "Hoge Kwaliteit Stream (192kbit MP3)",
+  format=%ffmpeg(
+    format = "mp3",
+    %audio(
+      codec = "libmp3lame",
+      b = "#{ICECAST_BITRATE_MP3}k",
+      ar = 48000,
+      ac = 2
+    )
+  ),
+  description="Hoge Kwaliteit Stream (192kbit MP3)",
   mount=ICECAST_MOUNT_MP3,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_LOW,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
-  description=
-    "Mobile Stream (96kbit AAC)",
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_LOW,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
+  description="Mobile Stream (96kbit AAC)",
   mount=ICECAST_MOUNT_AAC_LOW,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
-  description=
-    "Transport Stream (576kbit AAC)",
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
+  description="Transport Stream (576kbit AAC)",
   mount=ICECAST_MOUNT_AAC_HIGH,
   audio_source=radio_processed
 )
 
 # Dutch Media Exchange outputs (dual ingestion points)
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,
@@ -122,16 +114,15 @@ output_icecast_stream(
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,

--- a/conf/bredanu.liq
+++ b/conf/bredanu.liq
@@ -8,6 +8,7 @@
 %include "lib/30_silence.liq"
 %include "lib/40_source_fallback.liq"
 %include "lib/41_source_studio.liq"
+%include "lib/42_metadata.liq"
 %include "lib/50_processing.liq"
 %include "lib/60_output_icecast.liq"
 %include "lib/61_output_dab.liq"
@@ -35,11 +36,12 @@ let studio_b = create_studio_input(id="studio_b", port=SRT_PORT_SECONDARY)
 # Build radio source with fallback chain, force support, and server commands
 let radio =
   create_radio(
-    sources=[
-      ("studio_a", studio_a),
-      ("studio_b", studio_b),
-      ("fallback", emergency_fallback)
-    ]
+    sources=
+      [
+        ("studio_a", studio_a),
+        ("studio_b", studio_b),
+        ("fallback", emergency_fallback)
+      ]
   )
 
 # Create processed audio source
@@ -47,61 +49,68 @@ let radio_processed = create_processed_audio(radio)
 
 # Output streams - BredaNu uses processed audio
 output_icecast_stream(
-  format=%ffmpeg(
-    format = "mp3",
-    %audio(
-      codec = "libmp3lame",
-      b = "#{ICECAST_BITRATE_MP3}k",
-      ar = 48000,
-      ac = 2
-    )
-  ),
-  description="Hoge Kwaliteit Stream (192kbit MP3)",
+  format=
+    %ffmpeg(
+      format = "mp3",
+      %audio(
+        codec = "libmp3lame",
+        b = "#{ICECAST_BITRATE_MP3}k",
+        ar = 48000,
+        ac = 2
+      )
+    ),
+  description=
+    "Hoge Kwaliteit Stream (192kbit MP3)",
   mount=ICECAST_MOUNT_MP3,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_LOW,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
-  description="Mobile Stream (96kbit AAC)",
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_LOW,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
+  description=
+    "Mobile Stream (96kbit AAC)",
   mount=ICECAST_MOUNT_AAC_LOW,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
-  description="Transport Stream (576kbit AAC)",
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
+  description=
+    "Transport Stream (576kbit AAC)",
   mount=ICECAST_MOUNT_AAC_HIGH,
   audio_source=radio_processed
 )
 
 # Dutch Media Exchange outputs (dual ingestion points)
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,
@@ -113,15 +122,16 @@ output_icecast_stream(
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,

--- a/conf/lib/00_settings.liq
+++ b/conf/lib/00_settings.liq
@@ -80,6 +80,10 @@ let HLS_SEGMENT_DURATION =
 let HLS_SEGMENTS = int_of_string(environment.get("HLS_SEGMENTS", default="10"))
 let HLS_SEGMENTS_OVERHEAD =
   int_of_string(environment.get("HLS_SEGMENTS_OVERHEAD", default="5"))
+let HLS_METADATA_PORT =
+  int_of_string(environment.get("HLS_METADATA_PORT", default="7000"))
+let HLS_METADATA_BEARER_TOKEN =
+  environment.get("HLS_METADATA_BEARER_TOKEN", default="")
 
 # StereoTool configuration (optional)
 let STEREOTOOL_LICENSE = environment.get("STEREOTOOL_LICENSE", default="")

--- a/conf/lib/00_settings.liq
+++ b/conf/lib/00_settings.liq
@@ -85,6 +85,8 @@ let HLS_SEGMENT_DURATION =
 let HLS_SEGMENTS = int_of_string(environment.get("HLS_SEGMENTS", default="10"))
 let HLS_SEGMENTS_OVERHEAD =
   int_of_string(environment.get("HLS_SEGMENTS_OVERHEAD", default="5"))
+
+# Stream metadata endpoint (optional - bearer token required to enable)
 let STREAM_METADATA_PORT =
   int_of_string(environment.get("STREAM_METADATA_PORT", default="7000"))
 let STREAM_METADATA_BEARER_TOKEN =

--- a/conf/lib/00_settings.liq
+++ b/conf/lib/00_settings.liq
@@ -80,10 +80,10 @@ let HLS_SEGMENT_DURATION =
 let HLS_SEGMENTS = int_of_string(environment.get("HLS_SEGMENTS", default="10"))
 let HLS_SEGMENTS_OVERHEAD =
   int_of_string(environment.get("HLS_SEGMENTS_OVERHEAD", default="5"))
-let HLS_METADATA_PORT =
-  int_of_string(environment.get("HLS_METADATA_PORT", default="7000"))
-let HLS_METADATA_BEARER_TOKEN =
-  environment.get("HLS_METADATA_BEARER_TOKEN", default="")
+let STREAM_METADATA_PORT =
+  int_of_string(environment.get("STREAM_METADATA_PORT", default="7000"))
+let STREAM_METADATA_BEARER_TOKEN =
+  environment.get("STREAM_METADATA_BEARER_TOKEN", default="")
 
 # StereoTool configuration (optional)
 let STEREOTOOL_LICENSE = environment.get("STEREOTOOL_LICENSE", default="")

--- a/conf/lib/42_metadata.liq
+++ b/conf/lib/42_metadata.liq
@@ -1,0 +1,60 @@
+# Shared stream metadata endpoint
+# Inserts authenticated now-playing updates before the output fan-out.
+
+def register_stream_metadata_endpoint(radio_source) =
+  if
+    STREAM_METADATA_BEARER_TOKEN == ""
+  then
+    log(
+      label="metadata",
+      "Stream metadata endpoint disabled - STREAM_METADATA_BEARER_TOKEN not \
+       configured",
+      level=3
+    )
+  else
+    def stream_metadata_handler(req, res) =
+      res.header("Cache-Control", "no-store")
+
+      # Harbor lowercases incoming header names before handlers run
+      if
+        req.headers["authorization"] !=
+          "Bearer #{STREAM_METADATA_BEARER_TOKEN}"
+      then
+        res.status_code(401)
+        res.data("Unauthorized\n")
+      else
+        let title = req.query["title"]
+        let artist = req.query["artist"]
+
+        if
+          title == ""
+        then
+          res.status_code(400)
+          res.data(
+            "Missing title\n"
+          )
+        else
+          radio_source.insert_metadata([("artist", artist), ("title", title)])
+          res.status_code(204)
+          log(
+            label="metadata",
+            "Inserted stream metadata",
+            level=4
+          )
+        end
+      end
+    end
+
+    harbor.http.register(
+      port=STREAM_METADATA_PORT,
+      method="GET",
+      "/metadata",
+      stream_metadata_handler
+    )
+    log(
+      label="metadata",
+      "Stream metadata endpoint enabled on port #{STREAM_METADATA_PORT}",
+      level=3
+    )
+  end
+end

--- a/conf/lib/42_metadata.liq
+++ b/conf/lib/42_metadata.liq
@@ -12,6 +12,18 @@ def register_stream_metadata_endpoint(radio_source) =
       level=3
     )
   else
+    # Out-of-range ports would silently bind port mod 65536
+    if
+      STREAM_METADATA_PORT < 1 or STREAM_METADATA_PORT > 65535
+    then
+      error.raise(
+        error.invalid,
+        "STREAM_METADATA_PORT must be between 1 and 65535, got #{
+          STREAM_METADATA_PORT
+        }"
+      )
+    end
+
     def stream_metadata_handler(req, res) =
       res.header("Cache-Control", "no-store")
 
@@ -20,6 +32,11 @@ def register_stream_metadata_endpoint(radio_source) =
         req.headers["authorization"] !=
           "Bearer #{STREAM_METADATA_BEARER_TOKEN}"
       then
+        log(
+          label="metadata",
+          "Rejected metadata request: bad or missing bearer token",
+          level=3
+        )
         res.status_code(401)
         res.data("Unauthorized\n")
       else
@@ -29,17 +46,33 @@ def register_stream_metadata_endpoint(radio_source) =
         if
           title == ""
         then
+          log(
+            label="metadata",
+            "Rejected metadata request: missing title",
+            level=3
+          )
           res.status_code(400)
           res.data(
             "Missing title\n"
           )
         else
-          radio_source.insert_metadata([("artist", artist), ("title", title)])
+          # An omitted artist sends a title-only update instead of an empty
+          # artist tag
+          let new_metadata =
+            if
+              artist == ""
+            then
+              [("title", title)]
+            else
+              [("artist", artist), ("title", title)]
+            end
+
+          radio_source.insert_metadata(new_metadata)
           res.status_code(204)
           log(
             label="metadata",
-            "Inserted stream metadata",
-            level=4
+            "Inserted stream metadata: artist='#{artist}' title='#{title}'",
+            level=3
           )
         end
       end

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -440,6 +440,75 @@ def hls_segment_name(segment_metadata) =
   }"
 end
 
+def hls_header_value(headers, name) =
+  let normalized_name = string.case(name, lower=true)
+  list.fold(
+    fun (value, header) ->
+      begin
+        let (header_name, header_value) = header
+        if
+          string.case(header_name, lower=true) == normalized_name
+        then
+          header_value
+        else
+          value
+        end
+      end,
+    "",
+    headers
+  )
+end
+
+def hls_register_metadata_endpoint(hls_source) =
+  if
+    HLS_METADATA_BEARER_TOKEN == ""
+  then
+    log(
+      label="hls",
+      "HLS timed metadata endpoint disabled - HLS_METADATA_BEARER_TOKEN not configured",
+      level=3
+    )
+  else
+    def hls_metadata_handler(req, res) =
+      res.header("Cache-Control", "no-store")
+      let authorization = hls_header_value(req.headers, "authorization")
+      if
+        authorization != "Bearer #{HLS_METADATA_BEARER_TOKEN}"
+      then
+        res.status_code(401)
+        res.data("Unauthorized\n")
+      else
+        let title = list.assoc(default="", "title", req.query)
+        let artist = list.assoc(default="", "artist", req.query)
+
+        if
+          title == ""
+        then
+          res.status_code(400)
+          res.data("Missing title\n")
+        else
+          hls_source.insert_metadata([("artist", artist), ("title", title)])
+          res.status_code(204)
+          res.data("")
+          log(label="hls", "Inserted HLS timed metadata", level=4)
+        end
+      end
+    end
+
+    harbor.http.register(
+      port=HLS_METADATA_PORT,
+      method="GET",
+      "/metadata/hls",
+      hls_metadata_handler
+    )
+    log(
+      label="hls",
+      "HLS timed metadata endpoint enabled on port #{HLS_METADATA_PORT}",
+      level=3
+    )
+  end
+end
+
 def output_hls_stream(audio_source) =
   if
     HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
@@ -468,7 +537,10 @@ def output_hls_stream(audio_source) =
       ).{
         bandwidth = HLS_BITRATE_LOW * 1000 + 8000,
         codecs = "mp4a.40.5",
-        extname = "ts"
+        extname = "ts",
+        id3 = true,
+        id3_version = 3,
+        replay_id3 = true
       }
 
     let aac_mid =
@@ -484,7 +556,10 @@ def output_hls_stream(audio_source) =
       ).{
         bandwidth = HLS_BITRATE_MID * 1000 + 8000,
         codecs = "mp4a.40.2",
-        extname = "ts"
+        extname = "ts",
+        id3 = true,
+        id3_version = 3,
+        replay_id3 = true
       }
 
     let aac_high =
@@ -500,7 +575,10 @@ def output_hls_stream(audio_source) =
       ).{
         bandwidth = HLS_BITRATE_HIGH * 1000 + 8000,
         codecs = "mp4a.40.2",
-        extname = "ts"
+        extname = "ts",
+        id3 = true,
+        id3_version = 3,
+        replay_id3 = true
       }
 
     let hls_output =
@@ -515,6 +593,8 @@ def output_hls_stream(audio_source) =
         [("aac_48", aac_low), ("aac_96", aac_mid), ("aac_192", aac_high)],
         hls_source
       )
+
+    hls_register_metadata_endpoint(hls_source)
 
     let hls_remote_seeded = ref(false)
     let hls_synced_segments = ref([])

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -440,75 +440,6 @@ def hls_segment_name(segment_metadata) =
   }"
 end
 
-def hls_header_value(headers, name) =
-  let normalized_name = string.case(name, lower=true)
-  list.fold(
-    fun (value, header) ->
-      begin
-        let (header_name, header_value) = header
-        if
-          string.case(header_name, lower=true) == normalized_name
-        then
-          header_value
-        else
-          value
-        end
-      end,
-    "",
-    headers
-  )
-end
-
-def hls_register_metadata_endpoint(hls_source) =
-  if
-    HLS_METADATA_BEARER_TOKEN == ""
-  then
-    log(
-      label="hls",
-      "HLS timed metadata endpoint disabled - HLS_METADATA_BEARER_TOKEN not configured",
-      level=3
-    )
-  else
-    def hls_metadata_handler(req, res) =
-      res.header("Cache-Control", "no-store")
-      let authorization = hls_header_value(req.headers, "authorization")
-      if
-        authorization != "Bearer #{HLS_METADATA_BEARER_TOKEN}"
-      then
-        res.status_code(401)
-        res.data("Unauthorized\n")
-      else
-        let title = list.assoc(default="", "title", req.query)
-        let artist = list.assoc(default="", "artist", req.query)
-
-        if
-          title == ""
-        then
-          res.status_code(400)
-          res.data("Missing title\n")
-        else
-          hls_source.insert_metadata([("artist", artist), ("title", title)])
-          res.status_code(204)
-          res.data("")
-          log(label="hls", "Inserted HLS timed metadata", level=4)
-        end
-      end
-    end
-
-    harbor.http.register(
-      port=HLS_METADATA_PORT,
-      method="GET",
-      "/metadata/hls",
-      hls_metadata_handler
-    )
-    log(
-      label="hls",
-      "HLS timed metadata endpoint enabled on port #{HLS_METADATA_PORT}",
-      level=3
-    )
-  end
-end
-
 def output_hls_stream(audio_source) =
   if
     HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
@@ -522,6 +453,8 @@ def output_hls_stream(audio_source) =
     )
 
     # Buffer provides clock isolation from the live program chain.
+    # Source metadata is emitted as timed ID3 (v2.3, replayed per segment) in
+    # the MPEG-TS variants by default; no per-stream id3 settings needed.
     let hls_source = mksafe(buffer(audio_source))
 
     let aac_low =
@@ -537,10 +470,7 @@ def output_hls_stream(audio_source) =
       ).{
         bandwidth = HLS_BITRATE_LOW * 1000 + 8000,
         codecs = "mp4a.40.5",
-        extname = "ts",
-        id3 = true,
-        id3_version = 3,
-        replay_id3 = true
+        extname = "ts"
       }
 
     let aac_mid =
@@ -556,10 +486,7 @@ def output_hls_stream(audio_source) =
       ).{
         bandwidth = HLS_BITRATE_MID * 1000 + 8000,
         codecs = "mp4a.40.2",
-        extname = "ts",
-        id3 = true,
-        id3_version = 3,
-        replay_id3 = true
+        extname = "ts"
       }
 
     let aac_high =
@@ -575,10 +502,7 @@ def output_hls_stream(audio_source) =
       ).{
         bandwidth = HLS_BITRATE_HIGH * 1000 + 8000,
         codecs = "mp4a.40.2",
-        extname = "ts",
-        id3 = true,
-        id3_version = 3,
-        replay_id3 = true
+        extname = "ts"
       }
 
     let hls_output =
@@ -593,8 +517,6 @@ def output_hls_stream(audio_source) =
         [("aac_48", aac_low), ("aac_96", aac_mid), ("aac_192", aac_high)],
         hls_source
       )
-
-    hls_register_metadata_endpoint(hls_source)
 
     let hls_remote_seeded = ref(false)
     let hls_synced_segments = ref([])

--- a/conf/lib/90_radio.liq
+++ b/conf/lib/90_radio.liq
@@ -36,8 +36,7 @@ def register_radio_commands(s, ~sources) =
 
     # Get status command
     server.register(
-      description=
-        "Show current mode and active source",
+      description="Show current mode and active source",
       "#{source_id}.status",
       fun (_) ->
         begin
@@ -51,15 +50,13 @@ def register_radio_commands(s, ~sources) =
     let source_names = list.map(fun (item) -> fst(item), sources)
     let source_names_str =
       string.concat(
-        separator=
-          ", ",
+        separator=", ",
         source_names
       )
 
     # Force specific source command
     server.register(
-      description=
-        "Force a specific source (#{source_names_str})",
+      description="Force a specific source (#{source_names_str})",
       "#{source_id}.force",
       fun (arg) ->
         begin
@@ -76,8 +73,7 @@ def register_radio_commands(s, ~sources) =
 
     # Return to auto mode command
     server.register(
-      description=
-        "Return to automatic fallback mode",
+      description="Return to automatic fallback mode",
       "#{source_id}.auto",
       fun (_) ->
         begin
@@ -88,8 +84,7 @@ def register_radio_commands(s, ~sources) =
 
     # Skip to next available source command
     server.register(
-      description=
-        "Skip to next available source",
+      description="Skip to next available source",
       "#{source_id}.skip",
       fun (_) ->
         begin

--- a/conf/lib/90_radio.liq
+++ b/conf/lib/90_radio.liq
@@ -36,7 +36,8 @@ def register_radio_commands(s, ~sources) =
 
     # Get status command
     server.register(
-      description="Show current mode and active source",
+      description=
+        "Show current mode and active source",
       "#{source_id}.status",
       fun (_) ->
         begin
@@ -50,13 +51,15 @@ def register_radio_commands(s, ~sources) =
     let source_names = list.map(fun (item) -> fst(item), sources)
     let source_names_str =
       string.concat(
-        separator=", ",
+        separator=
+          ", ",
         source_names
       )
 
     # Force specific source command
     server.register(
-      description="Force a specific source (#{source_names_str})",
+      description=
+        "Force a specific source (#{source_names_str})",
       "#{source_id}.force",
       fun (arg) ->
         begin
@@ -73,7 +76,8 @@ def register_radio_commands(s, ~sources) =
 
     # Return to auto mode command
     server.register(
-      description="Return to automatic fallback mode",
+      description=
+        "Return to automatic fallback mode",
       "#{source_id}.auto",
       fun (_) ->
         begin
@@ -84,7 +88,8 @@ def register_radio_commands(s, ~sources) =
 
     # Skip to next available source command
     server.register(
-      description="Skip to next available source",
+      description=
+        "Skip to next available source",
       "#{source_id}.skip",
       fun (_) ->
         begin
@@ -123,6 +128,9 @@ def create_radio(~sources) =
 
   # Register server commands for source control
   register_radio_commands(radio, sources=sources)
+
+  # Accept external now-playing updates (no-op unless a bearer token is set)
+  register_stream_metadata_endpoint(radio)
 
   radio
 end

--- a/conf/rucphen.liq
+++ b/conf/rucphen.liq
@@ -36,12 +36,11 @@ let studio_b = create_studio_input(id="studio_b", port=SRT_PORT_SECONDARY)
 # Build radio source with fallback chain, force support, and server commands
 let radio =
   create_radio(
-    sources=
-      [
-        ("studio_a", studio_a),
-        ("studio_b", studio_b),
-        ("fallback", emergency_fallback)
-      ]
+    sources=[
+      ("studio_a", studio_a),
+      ("studio_b", studio_b),
+      ("fallback", emergency_fallback)
+    ]
   )
 
 # Create processed audio source
@@ -49,68 +48,61 @@ let radio_processed = create_processed_audio(radio)
 
 # Output streams - Rucphen uses processed audio
 output_icecast_stream(
-  format=
-    %ffmpeg(
-      format = "mp3",
-      %audio(
-        codec = "libmp3lame",
-        b = "#{ICECAST_BITRATE_MP3}k",
-        ar = 48000,
-        ac = 2
-      )
-    ),
-  description=
-    "Hoge Kwaliteit Stream (192kbit MP3)",
+  format=%ffmpeg(
+    format = "mp3",
+    %audio(
+      codec = "libmp3lame",
+      b = "#{ICECAST_BITRATE_MP3}k",
+      ar = 48000,
+      ac = 2
+    )
+  ),
+  description="Hoge Kwaliteit Stream (192kbit MP3)",
   mount=ICECAST_MOUNT_MP3,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_LOW,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
-  description=
-    "Mobile Stream (96kbit AAC)",
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_LOW,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
+  description="Mobile Stream (96kbit AAC)",
   mount=ICECAST_MOUNT_AAC_LOW,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
-  description=
-    "Transport Stream (576kbit AAC)",
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
+  description="Transport Stream (576kbit AAC)",
   mount=ICECAST_MOUNT_AAC_HIGH,
   audio_source=radio_processed
 )
 
 # Dutch Media Exchange outputs (dual ingestion points)
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,
@@ -122,16 +114,15 @@ output_icecast_stream(
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,

--- a/conf/rucphen.liq
+++ b/conf/rucphen.liq
@@ -8,6 +8,7 @@
 %include "lib/30_silence.liq"
 %include "lib/40_source_fallback.liq"
 %include "lib/41_source_studio.liq"
+%include "lib/42_metadata.liq"
 %include "lib/50_processing.liq"
 %include "lib/60_output_icecast.liq"
 %include "lib/61_output_dab.liq"
@@ -35,11 +36,12 @@ let studio_b = create_studio_input(id="studio_b", port=SRT_PORT_SECONDARY)
 # Build radio source with fallback chain, force support, and server commands
 let radio =
   create_radio(
-    sources=[
-      ("studio_a", studio_a),
-      ("studio_b", studio_b),
-      ("fallback", emergency_fallback)
-    ]
+    sources=
+      [
+        ("studio_a", studio_a),
+        ("studio_b", studio_b),
+        ("fallback", emergency_fallback)
+      ]
   )
 
 # Create processed audio source
@@ -47,61 +49,68 @@ let radio_processed = create_processed_audio(radio)
 
 # Output streams - Rucphen uses processed audio
 output_icecast_stream(
-  format=%ffmpeg(
-    format = "mp3",
-    %audio(
-      codec = "libmp3lame",
-      b = "#{ICECAST_BITRATE_MP3}k",
-      ar = 48000,
-      ac = 2
-    )
-  ),
-  description="Hoge Kwaliteit Stream (192kbit MP3)",
+  format=
+    %ffmpeg(
+      format = "mp3",
+      %audio(
+        codec = "libmp3lame",
+        b = "#{ICECAST_BITRATE_MP3}k",
+        ar = 48000,
+        ac = 2
+      )
+    ),
+  description=
+    "Hoge Kwaliteit Stream (192kbit MP3)",
   mount=ICECAST_MOUNT_MP3,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_LOW,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
-  description="Mobile Stream (96kbit AAC)",
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_LOW,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
+  description=
+    "Mobile Stream (96kbit AAC)",
   mount=ICECAST_MOUNT_AAC_LOW,
   audio_source=radio_processed
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
-  description="Transport Stream (576kbit AAC)",
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
+  description=
+    "Transport Stream (576kbit AAC)",
   mount=ICECAST_MOUNT_AAC_HIGH,
   audio_source=radio_processed
 )
 
 # Dutch Media Exchange outputs (dual ingestion points)
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,
@@ -113,15 +122,16 @@ output_icecast_stream(
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
   description="",
   mount=DME_MOUNT_POINT,
   audio_source=radio_processed,

--- a/conf/zuidwest.liq
+++ b/conf/zuidwest.liq
@@ -8,6 +8,7 @@
 %include "lib/30_silence.liq"
 %include "lib/40_source_fallback.liq"
 %include "lib/41_source_studio.liq"
+%include "lib/42_metadata.liq"
 %include "lib/50_processing.liq"
 %include "lib/60_output_icecast.liq"
 %include "lib/61_output_dab.liq"
@@ -22,11 +23,12 @@ let studio_b = create_studio_input(id="studio_b", port=SRT_PORT_SECONDARY)
 # Build radio source with fallback chain, force support, and server commands
 let radio =
   create_radio(
-    sources=[
-      ("studio_a", studio_a),
-      ("studio_b", studio_b),
-      ("fallback", emergency_fallback)
-    ]
+    sources=
+      [
+        ("studio_a", studio_a),
+        ("studio_b", studio_b),
+        ("fallback", emergency_fallback)
+      ]
   )
 
 # Start StereoTool for MicroMPX transport (not used in Liquidsoap audio chain)
@@ -34,46 +36,52 @@ let _ = create_processed_audio(radio)
 
 # Output streams - ZuidWest uses unprocessed audio
 output_icecast_stream(
-  format=%ffmpeg(
-    format = "mp3",
-    %audio(
-      codec = "libmp3lame",
-      b = "#{ICECAST_BITRATE_MP3}k",
-      ar = 48000,
-      ac = 2
-    )
-  ),
-  description="Hoge Kwaliteit Stream (192kbit MP3)",
+  format=
+    %ffmpeg(
+      format = "mp3",
+      %audio(
+        codec = "libmp3lame",
+        b = "#{ICECAST_BITRATE_MP3}k",
+        ar = 48000,
+        ac = 2
+      )
+    ),
+  description=
+    "Hoge Kwaliteit Stream (192kbit MP3)",
   mount=ICECAST_MOUNT_MP3,
   audio_source=radio
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_LOW,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
-  description="Mobile Stream (96kbit AAC)",
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_LOW,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
+  description=
+    "Mobile Stream (96kbit AAC)",
   mount=ICECAST_MOUNT_AAC_LOW,
   audio_source=radio
 )
 
 output_icecast_stream(
-  format=%fdkaac(
-    channels = 2,
-    samplerate = 48000,
-    bitrate = ICECAST_BITRATE_AAC_HIGH,
-    afterburner = true,
-    aot = 'mpeg4_aac_lc',
-    transmux = 'adts',
-    sbr_mode = true
-  ),
-  description="Transport Stream (576kbit AAC)",
+  format=
+    %fdkaac(
+      channels = 2,
+      samplerate = 48000,
+      bitrate = ICECAST_BITRATE_AAC_HIGH,
+      afterburner = true,
+      aot = 'mpeg4_aac_lc',
+      transmux = 'adts',
+      sbr_mode = true
+    ),
+  description=
+    "Transport Stream (576kbit AAC)",
   mount=ICECAST_MOUNT_AAC_HIGH,
   audio_source=radio
 )

--- a/conf/zuidwest.liq
+++ b/conf/zuidwest.liq
@@ -23,12 +23,11 @@ let studio_b = create_studio_input(id="studio_b", port=SRT_PORT_SECONDARY)
 # Build radio source with fallback chain, force support, and server commands
 let radio =
   create_radio(
-    sources=
-      [
-        ("studio_a", studio_a),
-        ("studio_b", studio_b),
-        ("fallback", emergency_fallback)
-      ]
+    sources=[
+      ("studio_a", studio_a),
+      ("studio_b", studio_b),
+      ("fallback", emergency_fallback)
+    ]
   )
 
 # Start StereoTool for MicroMPX transport (not used in Liquidsoap audio chain)
@@ -36,52 +35,46 @@ let _ = create_processed_audio(radio)
 
 # Output streams - ZuidWest uses unprocessed audio
 output_icecast_stream(
-  format=
-    %ffmpeg(
-      format = "mp3",
-      %audio(
-        codec = "libmp3lame",
-        b = "#{ICECAST_BITRATE_MP3}k",
-        ar = 48000,
-        ac = 2
-      )
-    ),
-  description=
-    "Hoge Kwaliteit Stream (192kbit MP3)",
+  format=%ffmpeg(
+    format = "mp3",
+    %audio(
+      codec = "libmp3lame",
+      b = "#{ICECAST_BITRATE_MP3}k",
+      ar = 48000,
+      ac = 2
+    )
+  ),
+  description="Hoge Kwaliteit Stream (192kbit MP3)",
   mount=ICECAST_MOUNT_MP3,
   audio_source=radio
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_LOW,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
-  description=
-    "Mobile Stream (96kbit AAC)",
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_LOW,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
+  description="Mobile Stream (96kbit AAC)",
   mount=ICECAST_MOUNT_AAC_LOW,
   audio_source=radio
 )
 
 output_icecast_stream(
-  format=
-    %fdkaac(
-      channels = 2,
-      samplerate = 48000,
-      bitrate = ICECAST_BITRATE_AAC_HIGH,
-      afterburner = true,
-      aot = 'mpeg4_aac_lc',
-      transmux = 'adts',
-      sbr_mode = true
-    ),
-  description=
-    "Transport Stream (576kbit AAC)",
+  format=%fdkaac(
+    channels = 2,
+    samplerate = 48000,
+    bitrate = ICECAST_BITRATE_AAC_HIGH,
+    afterburner = true,
+    aot = 'mpeg4_aac_lc',
+    transmux = 'adts',
+    sbr_mode = true
+  ),
+  description="Transport Stream (576kbit AAC)",
   mount=ICECAST_MOUNT_AAC_HIGH,
   audio_source=radio
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,26 +19,11 @@ services:
     env_file:
       - .env
     ports:
-      # SRT Input 1
-      - target: ${SRT_PORT_PRIMARY:-8888}
-        published: ${SRT_PORT_PRIMARY:-8888}
-        host_ip: ${SRT_BIND:-0.0.0.0}
-        protocol: udp
-      # SRT Input 2
-      - target: ${SRT_PORT_SECONDARY:-9999}
-        published: ${SRT_PORT_SECONDARY:-9999}
-        host_ip: ${SRT_BIND:-0.0.0.0}
-        protocol: udp
-      # StereoTool GUI
-      - target: 8080
-        published: ${STEREOTOOL_WEB_PORT:-8080}
-        host_ip: ${STEREOTOOL_WEB_BIND:-0.0.0.0}
-        protocol: tcp
-      # Stream metadata API
-      - target: ${STREAM_METADATA_PORT:-7000}
-        published: ${STREAM_METADATA_PORT:-7000}
-        host_ip: ${STREAM_METADATA_BIND:-127.0.0.1}
-        protocol: tcp
+      - '${SRT_BIND:-0.0.0.0}:${SRT_PORT_PRIMARY:-8888}:${SRT_PORT_PRIMARY:-8888}/udp' # SRT Input 1
+      - '${SRT_BIND:-0.0.0.0}:${SRT_PORT_SECONDARY:-9999}:${SRT_PORT_SECONDARY:-9999}/udp' # SRT Input 2
+      - '${STEREOTOOL_WEB_BIND:-0.0.0.0}:${STEREOTOOL_WEB_PORT:-8080}:8080' # StereoTool GUI (TCP)
+      # Stream metadata API (TCP)
+      - '${STREAM_METADATA_BIND:-127.0.0.1}:${STREAM_METADATA_PORT:-7000}:${STREAM_METADATA_PORT:-7000}'
     command: /scripts/radio.liq
     restart: unless-stopped
     user: "liquidsoap:liquidsoap"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
     env_file:
       - .env
     ports:
+      - name: hls-metadata-api
+        target: ${HLS_METADATA_PORT:-7000}
+        published: ${HLS_METADATA_PORT:-7000}
+        host_ip: ${HLS_METADATA_BIND:-127.0.0.1}
       - '0.0.0.0:8080:8080' # StereoTool GUI (TCP)
       - '0.0.0.0:8888:8888/udp' # SRT Input 1
       - '0.0.0.0:9999:9999/udp' # SRT Input 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - ./socket:/tmp/liquidsoap # Server socket
     environment:
       - TZ=${CONTAINER_TIMEZONE:-Europe/Amsterdam}
+      # Pin listener ports to the values Compose interpolated for the port
+      # mappings, so a shell override cannot diverge from env_file
+      - SRT_PORT_PRIMARY=${SRT_PORT_PRIMARY:-8888}
+      - SRT_PORT_SECONDARY=${SRT_PORT_SECONDARY:-9999}
+      - STREAM_METADATA_PORT=${STREAM_METADATA_PORT:-7000}
     env_file:
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,26 @@ services:
     env_file:
       - .env
     ports:
-      - name: hls-metadata-api
-        target: ${HLS_METADATA_PORT:-7000}
-        published: ${HLS_METADATA_PORT:-7000}
-        host_ip: ${HLS_METADATA_BIND:-127.0.0.1}
-      - '0.0.0.0:8080:8080' # StereoTool GUI (TCP)
-      - '0.0.0.0:8888:8888/udp' # SRT Input 1
-      - '0.0.0.0:9999:9999/udp' # SRT Input 2
+      # SRT Input 1
+      - target: ${SRT_PORT_PRIMARY:-8888}
+        published: ${SRT_PORT_PRIMARY:-8888}
+        host_ip: ${SRT_BIND:-0.0.0.0}
+        protocol: udp
+      # SRT Input 2
+      - target: ${SRT_PORT_SECONDARY:-9999}
+        published: ${SRT_PORT_SECONDARY:-9999}
+        host_ip: ${SRT_BIND:-0.0.0.0}
+        protocol: udp
+      # StereoTool GUI
+      - target: 8080
+        published: ${STEREOTOOL_WEB_PORT:-8080}
+        host_ip: ${STEREOTOOL_WEB_BIND:-0.0.0.0}
+        protocol: tcp
+      # Stream metadata API
+      - target: ${STREAM_METADATA_PORT:-7000}
+        published: ${STREAM_METADATA_PORT:-7000}
+        host_ip: ${STREAM_METADATA_BIND:-127.0.0.1}
+        protocol: tcp
     command: /scripts/radio.liq
     restart: unless-stopped
     user: "liquidsoap:liquidsoap"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,26 @@ services:
     env_file:
       - .env
     ports:
-      - '${SRT_BIND:-0.0.0.0}:${SRT_PORT_PRIMARY:-8888}:${SRT_PORT_PRIMARY:-8888}/udp' # SRT Input 1
-      - '${SRT_BIND:-0.0.0.0}:${SRT_PORT_SECONDARY:-9999}:${SRT_PORT_SECONDARY:-9999}/udp' # SRT Input 2
-      - '${STEREOTOOL_WEB_BIND:-0.0.0.0}:${STEREOTOOL_WEB_PORT:-8080}:8080' # StereoTool GUI (TCP)
-      # Stream metadata API (TCP)
-      - '${STREAM_METADATA_BIND:-127.0.0.1}:${STREAM_METADATA_PORT:-7000}:${STREAM_METADATA_PORT:-7000}'
+      # SRT Input 1
+      - target: ${SRT_PORT_PRIMARY:-8888}
+        published: ${SRT_PORT_PRIMARY:-8888}
+        host_ip: ${SRT_BIND:-0.0.0.0}
+        protocol: udp
+      # SRT Input 2
+      - target: ${SRT_PORT_SECONDARY:-9999}
+        published: ${SRT_PORT_SECONDARY:-9999}
+        host_ip: ${SRT_BIND:-0.0.0.0}
+        protocol: udp
+      # StereoTool GUI
+      - target: 8080
+        published: ${STEREOTOOL_WEB_PORT:-8080}
+        host_ip: ${STEREOTOOL_WEB_BIND:-0.0.0.0}
+        protocol: tcp
+      # Stream metadata API
+      - target: ${STREAM_METADATA_PORT:-7000}
+        published: ${STREAM_METADATA_PORT:-7000}
+        host_ip: ${STREAM_METADATA_BIND:-127.0.0.1}
+        protocol: tcp
     command: /scripts/radio.liq
     restart: unless-stopped
     user: "liquidsoap:liquidsoap"

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ LIQUIDSOAP_LIB_FILES=(
   "30_silence.liq"
   "40_source_fallback.liq"
   "41_source_studio.liq"
+  "42_metadata.liq"
   "50_processing.liq"
   "60_output_icecast.liq"
   "61_output_dab.liq"


### PR DESCRIPTION
## Summary

- add a shared, authenticated Liquidsoap endpoint (`GET /metadata`) for now-playing updates; one call reaches every stream output: Icecast MP3/AAC mounts, DME mounts, and all HLS variants
- metadata is inserted into the main radio source inside `create_radio()`, before processing and the output fan-out; the endpoint stays disabled until `STREAM_METADATA_BEARER_TOKEN` is configured
- HLS carries the metadata as timed ID3 in the MPEG-TS segments; Liquidsoap 2.4.5 emits timed ID3 (v2.3, replayed per segment) by default for mpegts, so no per-variant encoder settings are needed
- make Docker port bindings configurable (`SRT_BIND`, `STEREOTOOL_WEB_BIND`, `STREAM_METADATA_BIND`); the metadata API publishes on loopback by default, with private-network and remote-host setups documented
- add configuration examples for ZuidWest, Rucphen, and BredaNu, including the zwfm-metadata URL-output integration

## Affected stations

- ZuidWest FM
- Radio Rucphen
- BredaNu

## Validation

- Liquidsoap syntax validation for all station entrypoints with savonet/liquidsoap:v2.4.5
- endpoint behavior verified live on v2.4.5: 401 without credentials, 400 without title, 204 for a valid update
- ID3 defaults for mpegts verified against the Liquidsoap 2.4.5 source (hls_output.ml, ffmpeg_encoder_common.ml); ffprobe confirmed TPE1/TIT2 frames in a generated segment
- insert_metadata verified to produce no track marks or encoder restarts; HLS deduplicates identical metadata updates
- docker compose config --quiet
- dclint docker-compose.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional, bearer-token authenticated `GET /metadata` endpoint to submit title/artist “now playing” updates.
  - Propagates updates to supported outputs, including timed ID3 metadata for HLS.
  - Introduced configurable bind addresses/ports for SRT inputs, the StereoTool web UI, and the metadata API (defaulting to localhost for the metadata service).
- **Documentation**
  - Updated the README and example environment templates with `SRT_BIND`, `STEREOTOOL_WEB_BIND`, and `STREAM_METADATA_*` settings, including setup and security guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->