### PR TITLE
fix: fail fast when emergency fallback audio is missing or invalid

### DIFF
--- a/.env.bredanu.example
+++ b/.env.bredanu.example
@@ -58,7 +58,7 @@ SRT_PASSPHRASE=foxtrot-uniform-charlie-kilo
 # Fallback and silence handling
 
 # [OPTIONAL] Emergency audio file
-EMERGENCY_AUDIO_PATH=/audio/fallback.mp3  # Default: /audio/fallback.ogg
+EMERGENCY_AUDIO_PATH=/audio/fallback.ogg  # Default: /audio/fallback.ogg
 
 # [OPTIONAL] Silence detection parameters
 SILENCE_SWITCH_SECONDS=15.0    # Default: 15.0

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,7 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # [OPTIONAL] Automatic source switching on silence
 # SILENCE_SWITCH_SECONDS=15.0    # Default: 15.0 (switch after 15s silence)
 # AUDIO_VALID_SECONDS=15.0       # Default: 15.0 (need 15s audio to validate)
+# SILENCE_THRESHOLD=-40.0        # Default: -40.0 (dB level counted as silence)
 
 # ====================
 # SERVER SOCKET (RUNTIME CONTROL)

--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,13 @@ SRT_PASSPHRASE=change-this-to-a-secure-passphrase
 # How the system handles silence and missing inputs
 
 # [OPTIONAL] Emergency audio file when all inputs fail
+# The file must exist and be decodable or Liquidsoap refuses to start
 # EMERGENCY_AUDIO_PATH=/audio/fallback.ogg  # Default: /audio/fallback.ogg
+
+# [OPTIONAL] Allow a silent fallback when the emergency audio file is
+# missing or invalid. Development/testing only - keep false in production
+# so a broken fallback file fails at startup instead of causing dead air
+# EMERGENCY_ALLOW_BLANK=false    # Default: false
 
 # [OPTIONAL] Automatic source switching on silence
 # SILENCE_SWITCH_SECONDS=15.0    # Default: 15.0 (switch after 15s silence)

--- a/.env.rucphen.example
+++ b/.env.rucphen.example
@@ -21,7 +21,7 @@ SRT_PASSPHRASE=foxtrot-uniform-charlie-kilo
 # ====================
 # AUDIO FALLBACK & SILENCE DETECTION
 # ====================
-EMERGENCY_AUDIO_PATH=/audio/fallback.mp3
+EMERGENCY_AUDIO_PATH=/audio/fallback.ogg
 
 # ====================
 # STEREOTOOL AUDIO PROCESSING

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ flowchart LR
 
 The system delivers audio through dual redundant pathways. Liquidsoap prioritizes the main input (SRT 1). If it becomes unavailable or silent, the system automatically switches to SRT 2. Should both inputs fail, it falls back to an emergency audio file (configured via `EMERGENCY_AUDIO_PATH`). For maximum reliability, both inputs should receive the same broadcast via separate network paths.
 
+The emergency audio file is a required production dependency: at startup Liquidsoap verifies that the file exists and can be decoded, and refuses to start otherwise. This prevents a deployment from silently losing its last safety net. For development or testing without an audio file, set `EMERGENCY_ALLOW_BLANK=true` to explicitly accept a silent fallback.
+
 ### Components
 
 1. **Liquidsoap**: Core audio processing engine - handles input switching, fallback logic, and encoding
@@ -140,6 +142,7 @@ This table lists ALL environment variables used in the system. Variables without
 | `SERVER_SOCKET_ENABLED`           | Enable Unix socket for runtime control           | `true`                       | `true`                                                          | `conf/lib/90_server.liq`               | All             |
 | `SERVER_SOCKET_PATH`              | Unix socket file path                            | `/tmp/liquidsoap/liquidsoap.sock` | `/tmp/liquidsoap/liquidsoap.sock`                          | `conf/lib/90_server.liq`               | All             |
 | `EMERGENCY_AUDIO_PATH`            | Fallback audio file when all inputs fail         | `/audio/fallback.ogg`        | `/audio/noodband.mp3`                                           | `conf/lib/00_settings.liq`             | All             |
+| `EMERGENCY_ALLOW_BLANK`           | Allow silent fallback when emergency audio is missing/invalid (dev/test only) | `false` | `true`                                              | `conf/lib/00_settings.liq`             | All             |
 | `SILENCE_SWITCH_SECONDS`          | Max silence duration (seconds)                   | `15.0`                       | `20.0`                                                          | `conf/lib/00_settings.liq`             | All             |
 | `AUDIO_VALID_SECONDS`             | Min audio duration (seconds)                     | `15.0`                       | `10.0`                                                          | `conf/lib/00_settings.liq`             | All             |
 | **DAB+ Configuration (Optional)** |
@@ -248,7 +251,7 @@ When silence detection is **enabled** (default):
 
 - Studio inputs automatically switch away when silent for more than 15 seconds
 - If both studios are silent/disconnected, the system plays the fallback file
-- If no fallback file exists, the system plays silence
+- The fallback file is validated at startup: if it is missing or cannot be decoded, Liquidsoap refuses to start (unless `EMERGENCY_ALLOW_BLANK=true` explicitly allows a silent fallback for development/testing)
 - Provides automatic redundancy for unattended operation
 
 When silence detection is **disabled**:

--- a/README.md
+++ b/README.md
@@ -139,12 +139,13 @@ This table lists ALL environment variables used in the system. Variables without
 | `STEREOTOOL_LICENSE`              | StereoTool license key                           | _(none)_                     | `ABC123DEF456...`                                               | `conf/lib/00_settings.liq`             | All             |
 | `STEREOTOOL_WEB_PORT`             | StereoTool web interface port                    | `8080`                       | `8080`                                                          | `conf/lib/00_settings.liq`             | All             |
 | **Fallback & Control**            |
-| `SERVER_SOCKET_ENABLED`           | Enable Unix socket for runtime control           | `true`                       | `true`                                                          | `conf/lib/90_server.liq`               | All             |
-| `SERVER_SOCKET_PATH`              | Unix socket file path                            | `/tmp/liquidsoap/liquidsoap.sock` | `/tmp/liquidsoap/liquidsoap.sock`                          | `conf/lib/90_server.liq`               | All             |
+| `SERVER_SOCKET_ENABLED`           | Enable Unix socket for runtime control           | `true`                       | `true`                                                          | `conf/lib/80_server.liq`               | All             |
+| `SERVER_SOCKET_PATH`              | Unix socket file path                            | `/tmp/liquidsoap/liquidsoap.sock` | `/tmp/liquidsoap/liquidsoap.sock`                          | `conf/lib/80_server.liq`               | All             |
 | `EMERGENCY_AUDIO_PATH`            | Fallback audio file when all inputs fail         | `/audio/fallback.ogg`        | `/audio/noodband.mp3`                                           | `conf/lib/00_settings.liq`             | All             |
 | `EMERGENCY_ALLOW_BLANK`           | Allow silent fallback when emergency audio is missing/invalid (dev/test only) | `false` | `true`                                              | `conf/lib/00_settings.liq`             | All             |
 | `SILENCE_SWITCH_SECONDS`          | Max silence duration (seconds)                   | `15.0`                       | `20.0`                                                          | `conf/lib/00_settings.liq`             | All             |
 | `AUDIO_VALID_SECONDS`             | Min audio duration (seconds)                     | `15.0`                       | `10.0`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `SILENCE_THRESHOLD`               | Audio level (dB) below which input counts as silent | `-40.0`                   | `-45.0`                                                         | `conf/lib/00_settings.liq`             | All             |
 | **DAB+ Configuration (Optional)** |
 | `DAB_BITRATE`                     | DAB+ encoder bitrate                             | _(none)_                     | `128`                                                           | `conf/lib/00_settings.liq`             | All             |
 | `DAB_EDI_DESTINATIONS`            | DAB+ EDI destination(s)                          | _(none)_                     | `tcp://dab-mux.local:9001` or `tcp://dab1:9001,tcp://dab2:9002` | `conf/lib/00_settings.liq`             | All             |
@@ -251,7 +252,7 @@ When silence detection is **enabled** (default):
 
 - Studio inputs automatically switch away when silent for more than 15 seconds
 - If both studios are silent/disconnected, the system plays the fallback file
-- The fallback file is validated at startup: if it is missing or cannot be decoded, Liquidsoap refuses to start (unless `EMERGENCY_ALLOW_BLANK=true` explicitly allows a silent fallback for development/testing)
+- The fallback file is validated at startup (see [System Design](#system-design) and `EMERGENCY_ALLOW_BLANK`)
 - Provides automatic redundancy for unattended operation
 
 When silence detection is **disabled**:
@@ -271,6 +272,7 @@ The default silence detection parameters can be adjusted via environment variabl
 
 - `SILENCE_SWITCH_SECONDS`: Maximum silence duration in seconds (default: 15.0)
 - `AUDIO_VALID_SECONDS`: The minimum duration of continuous audio required for an input to be considered valid (default: 15.0)
+- `SILENCE_THRESHOLD`: Audio level in dB below which the input is considered silent (default: -40.0)
 
 ## Streaming to SRT Inputs
 

--- a/conf/lib/00_settings.liq
+++ b/conf/lib/00_settings.liq
@@ -56,9 +56,8 @@ let SILENCE_THRESHOLD =
 let EMERGENCY_AUDIO_PATH =
   environment.get("EMERGENCY_AUDIO_PATH", default="/audio/fallback.ogg")
 
-# Allow a silent (blank) emergency fallback when the audio file is missing
-# or unusable. Explicit opt-in for development/testing only - production
-# deployments should fail fast instead of risking dead air.
+# Opt-in silent fallback when the emergency audio file is unusable
+# (development/testing only)
 let EMERGENCY_ALLOW_BLANK =
   environment.get("EMERGENCY_ALLOW_BLANK", default="false") == "true"
 

--- a/conf/lib/00_settings.liq
+++ b/conf/lib/00_settings.liq
@@ -56,6 +56,12 @@ let SILENCE_THRESHOLD =
 let EMERGENCY_AUDIO_PATH =
   environment.get("EMERGENCY_AUDIO_PATH", default="/audio/fallback.ogg")
 
+# Allow a silent (blank) emergency fallback when the audio file is missing
+# or unusable. Explicit opt-in for development/testing only - production
+# deployments should fail fast instead of risking dead air.
+let EMERGENCY_ALLOW_BLANK =
+  environment.get("EMERGENCY_ALLOW_BLANK", default="false") == "true"
+
 # DAB+ configuration (optional - both required to enable)
 let DAB_BITRATE = environment.get("DAB_BITRATE", default="")
 let DAB_EDI_DESTINATIONS = environment.get("DAB_EDI_DESTINATIONS", default="")

--- a/conf/lib/40_source_fallback.liq
+++ b/conf/lib/40_source_fallback.liq
@@ -1,15 +1,88 @@
 # Emergency fallback source
 # Provides audio when all studio inputs fail
+#
+# The emergency audio file is a required production dependency. Startup
+# fails when the file is missing or cannot be decoded, so a broken
+# deployment surfaces immediately instead of as dead air later. Setting
+# EMERGENCY_ALLOW_BLANK=true explicitly opts in to a silent fallback
+# for development and testing.
 
-# Create fallback audio source - either from file or blank
-let fallback_audio =
+# Inspect the configured emergency audio file
+# Returns ("", duration in seconds) when the file is usable, or
+# (problem description, 0.) when not
+def emergency_audio_status() =
   if
-    file.exists(EMERGENCY_AUDIO_PATH)
+    not file.exists(EMERGENCY_AUDIO_PATH)
   then
-    source.drop.metadata(id="fallback_file", single(EMERGENCY_AUDIO_PATH))
+    (
+      "file does not exist",
+      0.
+    )
   else
+    let audio_duration = request.duration(EMERGENCY_AUDIO_PATH) ?? 0.
+    if
+      audio_duration <= 0.
+    then
+      (
+        "file cannot be decoded as audio",
+        0.
+      )
+    else
+      ("", audio_duration)
+    end
+  end
+end
+
+# Build the emergency fallback audio source
+# Fails fast (exit 1) when the configured file is unusable, unless a
+# silent fallback was explicitly allowed via EMERGENCY_ALLOW_BLANK=true
+def create_fallback_audio() =
+  let (problem, audio_duration) = emergency_audio_status()
+  if
+    problem == ""
+  then
+    log(
+      level=3,
+      label="fallback",
+      "Emergency fallback audio OK: #{EMERGENCY_AUDIO_PATH} (duration: #{
+        audio_duration
+      }s)"
+    )
+    source.drop.metadata(id="fallback_file", single(EMERGENCY_AUDIO_PATH))
+  elsif
+    EMERGENCY_ALLOW_BLANK
+  then
+    let warning =
+      "Emergency fallback audio #{problem}: #{EMERGENCY_AUDIO_PATH}. \
+       EMERGENCY_ALLOW_BLANK=true, so a SILENT fallback is used. Dead air will \
+       be broadcast when all studio inputs fail."
+    log(level=2, label="fallback", warning)
+    print(
+      "WARNING: #{warning}"
+    )
+    blank(id="fallback_blank")
+  else
+    let message =
+      "Emergency fallback audio #{problem}: #{EMERGENCY_AUDIO_PATH}"
+    log(level=1, label="fallback", message)
+    print(
+      "FATAL: #{message}"
+    )
+    print(
+      "Fix: provide a decodable audio file at this path (configured via \
+       EMERGENCY_AUDIO_PATH), or set EMERGENCY_ALLOW_BLANK=true to explicitly \
+       accept a silent fallback for development/testing."
+    )
+    exit(1)
+
+    # Unreachable - exit(1) terminates, but the branch must yield a source
     blank(id="fallback_blank")
   end
+end
+
+# Create fallback audio source - validated file, or blank when explicitly
+# allowed
+let fallback_audio = create_fallback_audio()
 
 # Blank source for when silence detection is disabled
 let fallback_disabled = blank(id="fallback_disabled")

--- a/conf/lib/40_source_fallback.liq
+++ b/conf/lib/40_source_fallback.liq
@@ -1,88 +1,54 @@
 # Emergency fallback source
 # Provides audio when all studio inputs fail
 #
-# The emergency audio file is a required production dependency. Startup
-# fails when the file is missing or cannot be decoded, so a broken
-# deployment surfaces immediately instead of as dead air later. Setting
-# EMERGENCY_ALLOW_BLANK=true explicitly opts in to a silent fallback
-# for development and testing.
+# The emergency audio file is validated at startup: a missing or
+# undecodable file aborts startup instead of surfacing as dead air later,
+# unless EMERGENCY_ALLOW_BLANK=true opts in to a silent fallback.
 
-# Inspect the configured emergency audio file
-# Returns ("", duration in seconds) when the file is usable, or
-# (problem description, 0.) when not
-def emergency_audio_status() =
+# Probe the configured emergency audio file; empty string when usable
+let fallback_problem =
   if
     not file.exists(EMERGENCY_AUDIO_PATH)
   then
-    (
-      "file does not exist",
-      0.
-    )
-  else
-    let audio_duration = request.duration(EMERGENCY_AUDIO_PATH) ?? 0.
-    if
-      audio_duration <= 0.
-    then
-      (
-        "file cannot be decoded as audio",
-        0.
-      )
-    else
-      ("", audio_duration)
-    end
-  end
-end
-
-# Build the emergency fallback audio source
-# Fails fast (exit 1) when the configured file is unusable, unless a
-# silent fallback was explicitly allowed via EMERGENCY_ALLOW_BLANK=true
-def create_fallback_audio() =
-  let (problem, audio_duration) = emergency_audio_status()
-  if
-    problem == ""
+    "file does not exist"
+  elsif
+    (request.duration(EMERGENCY_AUDIO_PATH) ?? 0.) <= 0.
   then
-    log(
-      level=3,
+    "file cannot be decoded as audio"
+  else
+    ""
+  end
+
+# Create fallback audio source - validated file, or blank when explicitly
+# allowed
+let fallback_audio =
+  if
+    fallback_problem == ""
+  then
+    log.important(
       label="fallback",
-      "Emergency fallback audio OK: #{EMERGENCY_AUDIO_PATH} (duration: #{
-        audio_duration
-      }s)"
+      "Emergency fallback audio OK: #{EMERGENCY_AUDIO_PATH}"
     )
     source.drop.metadata(id="fallback_file", single(EMERGENCY_AUDIO_PATH))
   elsif
     EMERGENCY_ALLOW_BLANK
   then
-    let warning =
-      "Emergency fallback audio #{problem}: #{EMERGENCY_AUDIO_PATH}. \
+    log.severe(
+      label="fallback",
+      "Emergency fallback audio #{fallback_problem}: #{EMERGENCY_AUDIO_PATH}. \
        EMERGENCY_ALLOW_BLANK=true, so a SILENT fallback is used. Dead air will \
        be broadcast when all studio inputs fail."
-    log(level=2, label="fallback", warning)
-    print(
-      "WARNING: #{warning}"
     )
     blank(id="fallback_blank")
   else
-    let message =
-      "Emergency fallback audio #{problem}: #{EMERGENCY_AUDIO_PATH}"
-    log(level=1, label="fallback", message)
-    print(
-      "FATAL: #{message}"
+    error.raise(
+      error.invalid,
+      "Emergency fallback audio #{fallback_problem}: #{EMERGENCY_AUDIO_PATH}. \
+       Provide a decodable audio file at this path, or set \
+       EMERGENCY_ALLOW_BLANK=true to explicitly accept a silent fallback for \
+       development/testing."
     )
-    print(
-      "Fix: provide a decodable audio file at this path (configured via \
-       EMERGENCY_AUDIO_PATH), or set EMERGENCY_ALLOW_BLANK=true to explicitly \
-       accept a silent fallback for development/testing."
-    )
-    exit(1)
-
-    # Unreachable - exit(1) terminates, but the branch must yield a source
-    blank(id="fallback_blank")
   end
-end
-
-# Create fallback audio source - validated file, or blank when explicitly
-# allowed
-let fallback_audio = create_fallback_audio()
 
 # Blank source for when silence detection is disabled
 let fallback_disabled = blank(id="fallback_disabled")


### PR DESCRIPTION
Closes #101

## Problem

When `EMERGENCY_AUDIO_PATH` did not exist, `conf/lib/40_source_fallback.liq` silently substituted `blank()`. With both SRT inputs down, Liquidsoap and all outputs stayed alive while broadcasting dead air, and liveness-based monitoring kept reporting a healthy service. An existing but corrupt file was even worse: it passed the old `file.exists` check and crashed the clock thread at startup with an opaque OCaml stack trace.

## Changes

**`conf/lib/40_source_fallback.liq`** - the emergency audio file is now treated as a required production dependency, validated at script evaluation time (before any output starts):

- `file.exists` catches a missing file.
- `request.duration` catches an existing but undecodable file (returns `null` for corrupt/empty files, a positive duration for valid ones - verified against Liquidsoap 2.4.5).
- On failure the log and stdout show the configured path, the specific problem, and the corrective action, then `exit(1)` stops the container visibly instead of leaving a silent zombie.
- On success the path and decoded duration are logged.

**`conf/lib/00_settings.liq`** - new `EMERGENCY_ALLOW_BLANK` env var (default `false`). Setting it to `true` is the explicit development/testing opt-in for the old silent behavior; it logs and prints a loud warning that dead air will be broadcast when all studio inputs fail.

**`.env.rucphen.example` / `.env.bredanu.example`** - these pointed to `/audio/fallback.mp3` while the installer downloads `/audio/fallback.ogg`. Out of the box those configs ran with a silent fallback without anyone noticing; with this change they would refuse to start. Fixed to match the installed asset.

**`.env.example` / `README.md`** - documented the new variable and the fail-fast behavior.

## Behavior matrix (verified with Docker, savonet/liquidsoap:v2.4.5)

| Scenario | Before | After |
|---|---|---|
| File missing | silent `blank()` fallback | `FATAL: Emergency fallback audio file does not exist: <path>` + fix hint, exit 1 |
| File corrupt/undecodable | crash at clock activation with OCaml stack trace | `FATAL: Emergency fallback audio file cannot be decoded as audio: <path>` + fix hint, exit 1 |
| File missing + `EMERGENCY_ALLOW_BLANK=true` | n/a | starts with `WARNING: ... a SILENT fallback is used. Dead air will be broadcast when all studio inputs fail.` |
| File valid | plays file | plays file, logs path + duration |

## Verification performed

- `liquidsoap -c` passes for `conf/zuidwest.liq`, `conf/rucphen.liq`, `conf/bredanu.liq` (same check as CI); the new code introduces no new warnings (the pre-existing `id` shadowing warnings remain).
- All four scenarios in the matrix above exercised end-to-end in Docker with fixture files (missing path, `/dev/urandom` garbage, valid audio).
- Both-studios-down runtime check: built the real `studio_a -> studio_b -> emergency_fallback` chain with unconnected SRT inputs and measured RMS of the resulting radio source for 15s; it produced audible fallback audio (peak RMS 0.57 with a test tone) instead of silence.
- Formatted with `liquidsoap-prettier`.

## Out of scope (remaining acceptance criteria from #101)

- Installer checksum pinning of the downloaded asset and repo-shipped runtime tests were intentionally left out to keep this PR focused on the Liquidsoap behavior.
- External monitoring of audio energy/content is a monitoring-stack concern; this PR makes the failure mode visible (container exits) rather than silent.