### PR TITLE
fix: wire `CONTAINER_TIMEZONE` to the container TZ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./socket:/tmp/liquidsoap # Server socket
       - ./hls:/hls
     environment:
-      - TZ=Europe/Amsterdam
+      - TZ=${CONTAINER_TIMEZONE:-Europe/Amsterdam}
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## Summary

`CONTAINER_TIMEZONE` is documented in README.md and offered in `.env.example` / `.env.bredanu.example`, but `docker-compose.yml` hardcoded `TZ=Europe/Amsterdam`, so setting the variable had no effect.

This wires it up (option 2 from the issue):

```yaml
- TZ=${CONTAINER_TIMEZONE:-Europe/Amsterdam}
```

Docker Compose reads the `.env` file next to `docker-compose.yml` for variable interpolation, so this works with the existing `/opt/liquidsoap` deployment layout without any installer changes. Existing setups are unaffected: with the variable unset, TZ stays `Europe/Amsterdam`.

## Verification

Ran `docker compose config` with a throwaway `.env`:

- without `CONTAINER_TIMEZONE`: renders `TZ: Europe/Amsterdam`
- with `CONTAINER_TIMEZONE=America/New_York`: renders `TZ: America/New_York`

Fixes #106