### PR TITLE
fix: wire `STEREOTOOL_WEB_PORT` to the StereoTool GUI port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This table lists ALL environment variables used in the system. Variables without
 | `SRT_PORT_SECONDARY`              | Secondary SRT listening port                     | `9999`                       | `9999`                                                          | `conf/lib/00_settings.liq`             | All             |
 | **Audio Processing**              |
 | `STEREOTOOL_LICENSE`              | StereoTool license key                           | _(none)_                     | `ABC123DEF456...`                                               | `conf/lib/00_settings.liq`             | All             |
-| `STEREOTOOL_WEB_PORT`             | StereoTool web interface port                    | `8080`                       | `8080`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `STEREOTOOL_WEB_PORT`             | StereoTool web interface host port               | `8080`                       | `8080`                                                          | `docker-compose.yml`                   | All             |
 | **Fallback & Control**            |
 | `SERVER_SOCKET_ENABLED`           | Enable Unix socket for runtime control           | `true`                       | `true`                                                          | `conf/lib/80_server.liq`               | All             |
 | `SERVER_SOCKET_PATH`              | Unix socket file path                            | `/tmp/liquidsoap/liquidsoap.sock` | `/tmp/liquidsoap/liquidsoap.sock`                          | `conf/lib/80_server.liq`               | All             |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     env_file:
       - .env
     ports:
-      - '0.0.0.0:8080:8080' # StereoTool GUI (TCP)
+      - '0.0.0.0:${STEREOTOOL_WEB_PORT:-8080}:8080' # StereoTool GUI (TCP)
       - '0.0.0.0:8888:8888/udp' # SRT Input 1
       - '0.0.0.0:9999:9999/udp' # SRT Input 2
     command: /scripts/radio.liq


### PR DESCRIPTION
## Summary

`STEREOTOOL_WEB_PORT` is documented in README.md and offered in `.env.example` / `.env.bredanu.example`, but `docker-compose.yml` hardcoded the StereoTool GUI port mapping as `0.0.0.0:8080:8080`, so setting the variable had no effect.

This wires it up (option 2 from the issue), same approach as #107 did for `CONTAINER_TIMEZONE`:

```yaml
- '0.0.0.0:${STEREOTOOL_WEB_PORT:-8080}:8080' # StereoTool GUI (TCP)
```

Only the host side is variable; the container-internal port stays 8080 since it is dictated by StereoTool's own configuration. The README table row now points at `docker-compose.yml` as the source instead of the incorrect `conf/lib/00_settings.liq`, and the description clarifies it is the host port.

Docker Compose reads the `.env` file next to `docker-compose.yml` for variable interpolation, so this works with the existing `/opt/liquidsoap` deployment layout without installer changes. Existing setups are unaffected: with the variable unset, the mapping stays `8080:8080`.

## Verification

Ran `docker compose config` with a throwaway `.env`:

- without `STEREOTOOL_WEB_PORT`: renders `published: 8080, target: 8080`
- with `STEREOTOOL_WEB_PORT=9090`: renders `published: 9090, target: 8080`

Fixes #105