### PR TITLE
fix: prevent HLS filesystem failures from stopping all radio outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ HLS is an optional CDN output and is not allowed to take the primary Icecast, DA
 - `/hls` is a dedicated tmpfs mount (64 MB, owned by the container user), so host disk-full conditions, read-only remounts, and ownership drift after deployment cannot reach the HLS writer. The live window needs roughly 2.5 MB; no host directory or manual `chown` is required anymore.
 - The HLS chain runs on its own Liquidsoap clock with an error handler. If writing still fails (for example the tmpfs itself fills up), only the HLS output degrades: the failure is logged at error level, `hls.status` reports `degraded: <reason>`, and a watchdog recreates the output with exponential backoff (5s doubling to 5 minutes) once `/hls` is writable again. Primary outputs keep running throughout, and recovery does not require a restart.
 
+Existing installations pick up the tmpfs mount by re-running `install.sh` (which refreshes `docker-compose.yml`); the old `./hls` host directory is unused afterwards and can be removed.
+
 Monitor `hls.status` via the server socket and alert when it reports `degraded` for longer than one backoff cycle.
 
 ## DME Integration (Dutch Media Exchange)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This table lists ALL environment variables used in the system. Variables without
 | `HLS_BUNNY_STORAGE_ZONE`          | Bunny Edge Storage zone name                     | _(none)_                     | `zwfm-hls`                                                      | `conf/lib/00_settings.liq`             | All             |
 | `HLS_BUNNY_ACCESS_KEY`            | Bunny Edge Storage read/write password           | _(none)_                     | `secret-storage-password`                                       | `conf/lib/00_settings.liq`             | All             |
 | `HLS_BUNNY_ENDPOINT`              | Bunny Edge Storage API endpoint                  | `storage.bunnycdn.com`       | `storage.bunnycdn.com`                                          | `conf/lib/00_settings.liq`             | All             |
-| `HLS_DIR`                         | Local HLS output directory                       | `/hls`                       | `/hls`                                                          | `conf/lib/00_settings.liq`             | All             |
+| `HLS_DIR`                         | Local HLS output directory (tmpfs mount)         | `/hls`                       | `/hls`                                                          | `conf/lib/00_settings.liq`             | All             |
 | `HLS_BITRATE_LOW`                 | Low HLS AAC bitrate in kbps                      | `48`                         | `48`                                                            | `conf/lib/00_settings.liq`             | All             |
 | `HLS_BITRATE_MID`                 | Mid HLS AAC bitrate in kbps                      | `96`                         | `96`                                                            | `conf/lib/00_settings.liq`             | All             |
 | `HLS_BITRATE_HIGH`                | High HLS AAC bitrate in kbps                     | `192`                        | `192`                                                           | `conf/lib/00_settings.liq`             | All             |
@@ -239,6 +239,7 @@ socat - UNIX-CONNECT:/opt/liquidsoap/socket/liquidsoap.sock
 | `silence.enable` | Enable silence detection |
 | `silence.disable` | Disable silence detection |
 | `silence.status` | Show silence detection state |
+| `hls.status` | Show HLS output health (`ok`, `degraded: <reason>`, or `disabled`) |
 
 All commands take effect immediately.
 
@@ -337,7 +338,7 @@ PAD allows sending metadata like song titles and station logos alongside the aud
 
 ## HLS Output via Bunny CDN
 
-The system supports optional audio-only HLS output. Liquidsoap writes a local HLS live window to `/hls`, then mirrors it to Bunny Edge Storage with native `http.put` and `http.delete` calls. No sidecar uploader or extra Docker image dependency is required.
+The system supports optional audio-only HLS output. Liquidsoap writes a local HLS live window to `/hls` (a 64 MB tmpfs mount defined in `docker-compose.yml`), then mirrors it to Bunny Edge Storage with native `http.put` and `http.delete` calls. No sidecar uploader or extra Docker image dependency is required.
 
 The HLS ladder is:
 
@@ -389,6 +390,15 @@ curl -sI https://hls.example.com/zuidwest/live.m3u8
 ```
 
 Expected results: three variants, AAC codec strings (`mp4a.40.5` and `mp4a.40.2`), playlist refreshes after the edge-rule TTL, and `.ts` segments are served with a longer cache lifetime.
+
+### Failure Isolation
+
+HLS is an optional CDN output and is not allowed to take the primary Icecast, DAB+, or DME outputs off air. Two layers enforce this:
+
+- `/hls` is a dedicated tmpfs mount (64 MB, owned by the container user), so host disk-full conditions, read-only remounts, and ownership drift after deployment cannot reach the HLS writer. The live window needs roughly 2.5 MB; no host directory or manual `chown` is required anymore.
+- The HLS chain runs on its own Liquidsoap clock with an error handler. If writing still fails (for example the tmpfs itself fills up), only the HLS output degrades: the failure is logged at error level, `hls.status` reports `degraded: <reason>`, and a watchdog recreates the output with exponential backoff (5s doubling to 5 minutes) once `/hls` is writable again. Primary outputs keep running throughout, and recovery does not require a restart.
+
+Monitor `hls.status` via the server socket and alert when it reports `degraded` for longer than one backoff cycle.
 
 ## DME Integration (Dutch Media Exchange)
 
@@ -449,6 +459,13 @@ For now-playing information and metadata routing, see the [zwfm-metadata](https:
 - Check Docker logs for `hls` upload, delete, or reconcile messages
 - Confirm the Bunny pull zone has a 1-2 second cache rule for `*.m3u8`
 - Confirm CORS includes `m3u8` and `ts` extensions
+
+**HLS output is degraded (`hls.status` reports `degraded`)**
+
+- The local HLS writer failed (unwritable or full `/hls`); primary outputs are unaffected
+- Check Docker logs for `HLS output degraded` lines with the exact reason
+- Verify the `/hls` tmpfs mount exists and is not full: `docker exec liquidsoap df -h /hls`
+- The watchdog retries automatically with backoff and logs `HLS output recovered` on success
 
 **StereoTool not processing**
 

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -1,5 +1,13 @@
 # HLS output configuration
 # Writes a local HLS window and mirrors it to Bunny Edge Storage.
+#
+# Failure isolation: the HLS chain runs on its own clock with an on_error
+# handler, so filesystem failures (permission denied, read-only, disk full)
+# degrade HLS instead of shutting down the whole Liquidsoap process. A
+# crashed output is detached by Liquidsoap and can never be restarted, so a
+# watchdog creates a fresh output once HLS_DIR is writable again. Do NOT add
+# persist_at to the output: writing state during the error-detach path
+# re-raises on the dead clock thread and takes the process down with it.
 
 let hls_bunny_headers = [("AccessKey", HLS_BUNNY_ACCESS_KEY), ("Expect", "")]
 let hls_main_playlist_name = "live.m3u8"
@@ -431,13 +439,28 @@ def hls_mirror_tick(
   end
 end
 
-# Timestamped segment names are never reused, even if state.json is lost
-# across restarts, so Bunny CDN can cache .aac segments with a long TTL.
+# Timestamped segment names are never reused across restarts, so Bunny CDN
+# can cache segments with a long TTL and no resume state is needed.
 def hls_segment_name(segment_metadata) =
   let ts = int_of_float(time())
   "#{segment_metadata.stream_name}_#{ts}_#{segment_metadata.position}.#{
     segment_metadata.extname
   }"
+end
+
+# Retry backoff for recreating a degraded HLS output
+let hls_retry_delay_initial = 5.0
+let hls_retry_delay_max = 300.0
+let hls_backoff_reset_seconds = 120.0
+
+def hls_next_retry_delay(current) =
+  if
+    current * 2.0 > hls_retry_delay_max
+  then
+    hls_retry_delay_max
+  else
+    current * 2.0
+  end
 end
 
 def output_hls_stream(audio_source) =
@@ -452,8 +475,38 @@ def output_hls_stream(audio_source) =
       level=3
     )
 
-    # Buffer provides clock isolation from the live program chain.
+    # Buffer decouples the HLS chain from the live program chain; the
+    # dedicated clock's on_error handler below contains streaming errors so
+    # a failing HLS output is detached instead of stopping the process.
     let hls_source = mksafe(buffer(audio_source))
+
+    let hls_degraded = ref(false)
+    let hls_last_error = ref("")
+    let hls_last_error_time = ref(0.0)
+    let hls_retry_at = ref(0.0)
+    let hls_retry_delay = ref(hls_retry_delay_initial)
+
+    clock.assign_new(
+      id="hls_clock",
+      on_error=fun (err) ->
+        begin
+          let err = error.methods(err)
+          hls_degraded := true
+          hls_last_error :=
+            "#{err.kind}: #{err.message}"
+          hls_last_error_time := time()
+          hls_retry_at := time() + hls_retry_delay()
+          hls_retry_delay := hls_next_retry_delay(hls_retry_delay())
+          log(
+            label="hls",
+            "HLS output degraded (primary outputs unaffected): #{
+              hls_last_error()
+            }",
+            level=2
+          )
+        end,
+      [hls_source]
+    )
 
     let aac_low =
       %ffmpeg(
@@ -503,26 +556,186 @@ def output_hls_stream(audio_source) =
         extname = "ts"
       }
 
-    let hls_output =
+    def hls_dir_writable() =
+      let probe_path = "#{HLS_DIR}/.hls-write-probe"
+      try
+        file.write(data="probe", probe_path)
+        file.remove(probe_path)
+        true
+      catch _ do
+        false
+      end
+    end
+
+    # Each (re)start begins a fresh timeline (timestamped segment names), so
+    # leftovers from the previous generation are dead weight: "liq...tmp"
+    # temp files from a crashed output plus its segments and playlists. Once
+    # removed locally, the mirror also retires them remotely.
+    def hls_remove_stale_local_files() =
+      def is_stale(fname) =
+        let name = path.basename(fname)
+        r/^liq.*tmp$/.test(name) or hls_is_sync_file_name(name)
+      end
+
+      try
+        list.iter(
+          fun (fname) ->
+            begin
+              if
+                is_stale(fname)
+              then
+                try
+                  file.remove(fname)
+                catch _ do
+                  ()
+                end
+              end
+            end,
+          file.ls(absolute=true, HLS_DIR)
+        )
+      catch _ do
+        ()
+      end
+    end
+
+    # No persist_at: segment names are timestamped and never reused (see
+    # hls_segment_name), and persist_at breaks the error containment above.
+    def start_hls_output() =
       output.file.hls(
+        id="hls",
         playlist=hls_main_playlist_name,
         segment_duration=HLS_SEGMENT_DURATION,
         segments=HLS_SEGMENTS,
         segments_overhead=HLS_SEGMENTS_OVERHEAD,
         segment_name=hls_segment_name,
-        persist_at="state.json",
         HLS_DIR,
         [("aac_48", aac_low), ("aac_96", aac_mid), ("aac_192", aac_high)],
         hls_source
       )
+    end
+
+    def try_start_hls_output() =
+      if
+        hls_dir_writable()
+      then
+        hls_remove_stale_local_files()
+        ignore(start_hls_output())
+        hls_degraded := false
+        log(
+          label="hls",
+          "HLS output started",
+          level=3
+        )
+        true
+      else
+        false
+      end
+    end
+
+    # Preflight: start degraded instead of crashing when HLS_DIR is not
+    # writable at startup; the watchdog below keeps retrying.
+    if
+      not try_start_hls_output()
+    then
+      hls_degraded := true
+      hls_last_error :=
+        "HLS_DIR #{HLS_DIR} is not writable"
+      hls_last_error_time := time()
+      log(
+        label="hls",
+        "HLS output degraded at startup (primary outputs unaffected): #{
+          hls_last_error()
+        }",
+        level=2
+      )
+    end
+
+    def hls_watchdog() =
+      if
+        hls_degraded()
+      then
+        if
+          time() >= hls_retry_at()
+        then
+          if
+            try_start_hls_output()
+          then
+            log(
+              label="hls",
+              "HLS output recovered",
+              level=2
+            )
+          else
+            let retry_in = hls_retry_delay()
+            hls_retry_at := time() + retry_in
+            hls_retry_delay := hls_next_retry_delay(retry_in)
+            log(
+              label="hls",
+              "HLS output still degraded (#{hls_last_error()}); next attempt in #{
+                retry_in
+              }s",
+              level=2
+            )
+          end
+        end
+      else
+        # Forget the backoff once the output has been stable for a while
+        if
+          hls_retry_delay() != hls_retry_delay_initial
+          and time() - hls_last_error_time() > hls_backoff_reset_seconds
+        then
+          hls_retry_delay := hls_retry_delay_initial
+        end
+      end
+    end
+
+    thread.run(
+      fast=false,
+      every=1.0,
+      on_error=fun (err) ->
+        begin
+          let err = error.methods(err)
+          log(
+            label="hls",
+            "HLS watchdog error: #{err.kind}: #{err.message}",
+            level=2
+          )
+        end,
+      fun () -> hls_watchdog()
+    )
+
+    server.register(
+      description="Show HLS output health",
+      "hls.status",
+      fun (_) ->
+        if
+          hls_degraded()
+        then
+          "degraded: #{hls_last_error()}"
+        else
+          "ok"
+        end
+    )
 
     let hls_remote_seeded = ref(false)
     let hls_synced_segments = ref([])
     let hls_synced_playlists = ref([])
+
+    # on_error keeps an unexpected mirror failure (e.g. HLS_DIR unreadable)
+    # from killing the process: an uncaught error in a scheduler task is fatal.
     thread.run(
       fast=false,
       delay=1.0,
       every=1.0,
+      on_error=fun (err) ->
+        begin
+          let err = error.methods(err)
+          log(
+            label="hls",
+            "HLS mirror tick error: #{err.kind}: #{err.message}",
+            level=2
+          )
+        end,
       fun () ->
         hls_mirror_tick(
           hls_remote_seeded,
@@ -536,6 +749,11 @@ def output_hls_stream(audio_source) =
       "HLS output disabled - HLS_BUNNY_STORAGE_ZONE and/or HLS_BUNNY_ACCESS_KEY \
        not configured",
       level=3
+    )
+    server.register(
+      description="Show HLS output health",
+      "hls.status",
+      fun (_) -> "disabled"
     )
   end
 end

--- a/conf/lib/62_output_hls.liq
+++ b/conf/lib/62_output_hls.liq
@@ -453,209 +453,200 @@ let hls_retry_delay_initial = 5.0
 let hls_retry_delay_max = 300.0
 let hls_backoff_reset_seconds = 120.0
 
-def hls_next_retry_delay(current) =
-  if
-    current * 2.0 > hls_retry_delay_max
-  then
-    hls_retry_delay_max
-  else
-    current * 2.0
+def hls_dir_writable() =
+  let probe_path = "#{HLS_DIR}/.hls-write-probe"
+  try
+    file.write(data="probe", probe_path)
+    file.remove(probe_path)
+    true
+  catch _ do
+    false
   end
 end
 
-def output_hls_stream(audio_source) =
-  if
-    HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
-  then
-    log(
-      label="hls",
-      "HLS output enabled - writing #{HLS_SEGMENTS}x#{HLS_SEGMENT_DURATION}s to #{
-        HLS_DIR
-      }, uploading to #{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/",
-      level=3
-    )
+# Each (re)start begins a fresh timeline (timestamped segment names), so
+# leftovers from the previous generation are dead weight: "liq...tmp" temp
+# files from a crashed output plus its segments and playlists. Once removed
+# locally, the mirror also retires them remotely.
+def hls_remove_stale_local_files() =
+  def is_stale(name) =
+    r/^liq.*tmp$/.test(name) or hls_is_sync_file_name(name)
+  end
 
-    # Buffer decouples the HLS chain from the live program chain; the
-    # dedicated clock's on_error handler below contains streaming errors so
-    # a failing HLS output is detached instead of stopping the process.
-    let hls_source = mksafe(buffer(audio_source))
-
-    let hls_degraded = ref(false)
-    let hls_last_error = ref("")
-    let hls_last_error_time = ref(0.0)
-    let hls_retry_at = ref(0.0)
-    let hls_retry_delay = ref(hls_retry_delay_initial)
-
-    clock.assign_new(
-      id="hls_clock",
-      on_error=fun (err) ->
-        begin
-          let err = error.methods(err)
-          hls_degraded := true
-          hls_last_error :=
-            "#{err.kind}: #{err.message}"
-          hls_last_error_time := time()
-          hls_retry_at := time() + hls_retry_delay()
-          hls_retry_delay := hls_next_retry_delay(hls_retry_delay())
-          log(
-            label="hls",
-            "HLS output degraded (primary outputs unaffected): #{
-              hls_last_error()
-            }",
-            level=2
-          )
-        end,
-      [hls_source]
-    )
-
-    let aac_low =
-      %ffmpeg(
-        format = "mpegts",
-        %audio(
-          codec = "libfdk_aac",
-          b = "#{HLS_BITRATE_LOW}k",
-          ar = 48000,
-          ac = 2,
-          profile = "aac_he"
-        )
-      ).{
-        bandwidth = HLS_BITRATE_LOW * 1000 + 8000,
-        codecs = "mp4a.40.5",
-        extname = "ts"
-      }
-
-    let aac_mid =
-      %ffmpeg(
-        format = "mpegts",
-        %audio(
-          codec = "libfdk_aac",
-          b = "#{HLS_BITRATE_MID}k",
-          ar = 48000,
-          ac = 2,
-          profile = "aac_low"
-        )
-      ).{
-        bandwidth = HLS_BITRATE_MID * 1000 + 8000,
-        codecs = "mp4a.40.2",
-        extname = "ts"
-      }
-
-    let aac_high =
-      %ffmpeg(
-        format = "mpegts",
-        %audio(
-          codec = "libfdk_aac",
-          b = "#{HLS_BITRATE_HIGH}k",
-          ar = 48000,
-          ac = 2,
-          profile = "aac_low"
-        )
-      ).{
-        bandwidth = HLS_BITRATE_HIGH * 1000 + 8000,
-        codecs = "mp4a.40.2",
-        extname = "ts"
-      }
-
-    def hls_dir_writable() =
-      let probe_path = "#{HLS_DIR}/.hls-write-probe"
+  list.iter(
+    fun (fname) ->
       try
-        file.write(data="probe", probe_path)
-        file.remove(probe_path)
-        true
-      catch _ do
-        false
-      end
-    end
-
-    # Each (re)start begins a fresh timeline (timestamped segment names), so
-    # leftovers from the previous generation are dead weight: "liq...tmp"
-    # temp files from a crashed output plus its segments and playlists. Once
-    # removed locally, the mirror also retires them remotely.
-    def hls_remove_stale_local_files() =
-      def is_stale(fname) =
-        let name = path.basename(fname)
-        r/^liq.*tmp$/.test(name) or hls_is_sync_file_name(name)
-      end
-
-      try
-        list.iter(
-          fun (fname) ->
-            begin
-              if
-                is_stale(fname)
-              then
-                try
-                  file.remove(fname)
-                catch _ do
-                  ()
-                end
-              end
-            end,
-          file.ls(absolute=true, HLS_DIR)
-        )
+        file.remove(fname)
       catch _ do
         ()
-      end
+      end,
+    try
+      hls_local_files(is_stale)
+    catch _ do
+      []
     end
+  )
+end
 
-    # No persist_at: segment names are timestamped and never reused (see
-    # hls_segment_name), and persist_at breaks the error containment above.
-    def start_hls_output() =
-      output.file.hls(
-        id="hls",
-        playlist=hls_main_playlist_name,
-        segment_duration=HLS_SEGMENT_DURATION,
-        segments=HLS_SEGMENTS,
-        segments_overhead=HLS_SEGMENTS_OVERHEAD,
-        segment_name=hls_segment_name,
-        HLS_DIR,
-        [("aac_48", aac_low), ("aac_96", aac_mid), ("aac_192", aac_high)],
-        hls_source
-      )
-    end
-
-    def try_start_hls_output() =
-      if
-        hls_dir_writable()
-      then
-        hls_remove_stale_local_files()
-        ignore(start_hls_output())
-        hls_degraded := false
-        log(
-          label="hls",
-          "HLS output started",
-          level=3
-        )
-        true
-      else
-        false
-      end
-    end
-
-    # Preflight: start degraded instead of crashing when HLS_DIR is not
-    # writable at startup; the watchdog below keeps retrying.
-    if
-      not try_start_hls_output()
-    then
-      hls_degraded := true
-      hls_last_error :=
-        "HLS_DIR #{HLS_DIR} is not writable"
-      hls_last_error_time := time()
+# An error raised out of a recurring thread.run task stops that task for
+# good (the on_error wrapper silences the error but never reschedules), so
+# each tick catches and logs its own errors instead.
+def hls_guard_task(what, task) =
+  fun () ->
+    try
+      task()
+    catch err do
       log(
         label="hls",
-        "HLS output degraded at startup (primary outputs unaffected): #{
-          hls_last_error()
-        }",
+        "HLS #{what} error: #{err.kind}: #{err.message}",
         level=2
       )
     end
+end
 
-    def hls_watchdog() =
-      if
-        hls_degraded()
-      then
+def output_hls_stream(audio_source) =
+  let hls_status =
+    if
+      HLS_BUNNY_STORAGE_ZONE != "" and HLS_BUNNY_ACCESS_KEY != ""
+    then
+      log(
+        label="hls",
+        "HLS output enabled - writing #{HLS_SEGMENTS}x#{HLS_SEGMENT_DURATION}s \
+         to #{HLS_DIR}, uploading to #{HLS_BUNNY_STORAGE_ZONE}/#{STATION_ID}/",
+        level=3
+      )
+
+      # Buffer decouples the HLS chain from the live program chain; the
+      # dedicated clock's on_error handler below contains streaming errors so
+      # a failing HLS output is detached instead of stopping the process.
+      let hls_source = mksafe(buffer(audio_source))
+
+      let hls_last_error = ref("")
+      let hls_retry_at = ref(0.0)
+      let hls_retry_delay = ref(hls_retry_delay_initial)
+
+      def hls_degraded() =
+        hls_last_error() != ""
+      end
+
+      # Record the failure, log it, and arm the next recreation attempt.
+      def hls_mark_degraded(reason) =
+        let retry_in = hls_retry_delay()
+        hls_last_error := reason
+        hls_retry_at := time() + retry_in
+        hls_retry_delay := min(retry_in * 2.0, hls_retry_delay_max)
+        log(
+          label="hls",
+          "HLS output degraded (primary outputs unaffected): #{reason}; next \
+           attempt in #{retry_in}s",
+          level=2
+        )
+      end
+
+      clock.assign_new(
+        id="hls_clock",
+        on_error=fun (err) ->
+          hls_mark_degraded(
+            "#{error.kind(err)}: #{error.message(err)}"
+          ),
+        [hls_source]
+      )
+
+      let aac_low =
+        %ffmpeg(
+          format = "mpegts",
+          %audio(
+            codec = "libfdk_aac",
+            b = "#{HLS_BITRATE_LOW}k",
+            ar = 48000,
+            ac = 2,
+            profile = "aac_he"
+          )
+        ).{
+          bandwidth = HLS_BITRATE_LOW * 1000 + 8000,
+          codecs = "mp4a.40.5",
+          extname = "ts"
+        }
+
+      let aac_mid =
+        %ffmpeg(
+          format = "mpegts",
+          %audio(
+            codec = "libfdk_aac",
+            b = "#{HLS_BITRATE_MID}k",
+            ar = 48000,
+            ac = 2,
+            profile = "aac_low"
+          )
+        ).{
+          bandwidth = HLS_BITRATE_MID * 1000 + 8000,
+          codecs = "mp4a.40.2",
+          extname = "ts"
+        }
+
+      let aac_high =
+        %ffmpeg(
+          format = "mpegts",
+          %audio(
+            codec = "libfdk_aac",
+            b = "#{HLS_BITRATE_HIGH}k",
+            ar = 48000,
+            ac = 2,
+            profile = "aac_low"
+          )
+        ).{
+          bandwidth = HLS_BITRATE_HIGH * 1000 + 8000,
+          codecs = "mp4a.40.2",
+          extname = "ts"
+        }
+
+      def try_start_hls_output() =
         if
-          time() >= hls_retry_at()
+          hls_dir_writable()
+        then
+          hls_remove_stale_local_files()
+
+          # No persist_at: segment names are timestamped and never reused (see
+          # hls_segment_name), and persist_at breaks the error containment
+          # above.
+          ignore(
+            output.file.hls(
+              id="hls",
+              playlist=hls_main_playlist_name,
+              segment_duration=HLS_SEGMENT_DURATION,
+              segments=HLS_SEGMENTS,
+              segments_overhead=HLS_SEGMENTS_OVERHEAD,
+              segment_name=hls_segment_name,
+              HLS_DIR,
+              [("aac_48", aac_low), ("aac_96", aac_mid), ("aac_192", aac_high)],
+              hls_source
+            )
+          )
+          hls_last_error := ""
+          log(
+            label="hls",
+            "HLS output started",
+            level=3
+          )
+          true
+        else
+          false
+        end
+      end
+
+      # Preflight: start degraded instead of crashing when HLS_DIR is not
+      # writable at startup; the watchdog below keeps retrying.
+      if
+        not try_start_hls_output()
+      then
+        hls_mark_degraded(
+          "HLS_DIR #{HLS_DIR} is not writable"
+        )
+      end
+
+      def hls_watchdog() =
+        if
+          hls_degraded() and time() >= hls_retry_at()
         then
           if
             try_start_hls_output()
@@ -666,48 +657,44 @@ def output_hls_stream(audio_source) =
               level=2
             )
           else
-            let retry_in = hls_retry_delay()
-            hls_retry_at := time() + retry_in
-            hls_retry_delay := hls_next_retry_delay(retry_in)
-            log(
-              label="hls",
-              "HLS output still degraded (#{hls_last_error()}); next attempt in #{
-                retry_in
-              }s",
-              level=2
-            )
+            hls_mark_degraded(hls_last_error())
           end
-        end
-      else
-        # Forget the backoff once the output has been stable for a while
-        if
-          hls_retry_delay() != hls_retry_delay_initial
-          and time() - hls_last_error_time() > hls_backoff_reset_seconds
+        elsif
+          not hls_degraded()
+          and hls_retry_delay() != hls_retry_delay_initial
+          and time() - hls_retry_at() > hls_backoff_reset_seconds
         then
+          # Forget the backoff once the output has been stable for a while
           hls_retry_delay := hls_retry_delay_initial
         end
       end
-    end
 
-    thread.run(
-      fast=false,
-      every=1.0,
-      on_error=fun (err) ->
-        begin
-          let err = error.methods(err)
-          log(
-            label="hls",
-            "HLS watchdog error: #{err.kind}: #{err.message}",
-            level=2
-          )
-        end,
-      fun () -> hls_watchdog()
-    )
+      thread.run(
+        fast=false,
+        every=hls_retry_delay_initial,
+        hls_guard_task("watchdog", hls_watchdog)
+      )
 
-    server.register(
-      description="Show HLS output health",
-      "hls.status",
-      fun (_) ->
+      let hls_remote_seeded = ref(false)
+      let hls_synced_segments = ref([])
+      let hls_synced_playlists = ref([])
+
+      thread.run(
+        fast=false,
+        delay=1.0,
+        every=1.0,
+        hls_guard_task(
+          "mirror tick",
+          fun () ->
+            hls_mirror_tick(
+              hls_remote_seeded,
+              hls_synced_segments,
+              hls_synced_playlists
+            )
+        )
+      )
+
+      fun () ->
         if
           hls_degraded()
         then
@@ -715,45 +702,19 @@ def output_hls_stream(audio_source) =
         else
           "ok"
         end
-    )
+    else
+      log(
+        label="hls",
+        "HLS output disabled - HLS_BUNNY_STORAGE_ZONE and/or \
+         HLS_BUNNY_ACCESS_KEY not configured",
+        level=3
+      )
+      fun () -> "disabled"
+    end
 
-    let hls_remote_seeded = ref(false)
-    let hls_synced_segments = ref([])
-    let hls_synced_playlists = ref([])
-
-    # on_error keeps an unexpected mirror failure (e.g. HLS_DIR unreadable)
-    # from killing the process: an uncaught error in a scheduler task is fatal.
-    thread.run(
-      fast=false,
-      delay=1.0,
-      every=1.0,
-      on_error=fun (err) ->
-        begin
-          let err = error.methods(err)
-          log(
-            label="hls",
-            "HLS mirror tick error: #{err.kind}: #{err.message}",
-            level=2
-          )
-        end,
-      fun () ->
-        hls_mirror_tick(
-          hls_remote_seeded,
-          hls_synced_segments,
-          hls_synced_playlists
-        )
-    )
-  else
-    log(
-      label="hls",
-      "HLS output disabled - HLS_BUNNY_STORAGE_ZONE and/or HLS_BUNNY_ACCESS_KEY \
-       not configured",
-      level=3
-    )
-    server.register(
-      description="Show HLS output health",
-      "hls.status",
-      fun (_) -> "disabled"
-    )
-  end
+  server.register(
+    description="Show HLS output health",
+    "hls.status",
+    fun (_) -> hls_status()
+  )
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
       - ./audio:/audio
       - ./stereotool:/var/cache/liquidsoap/
       - ./socket:/tmp/liquidsoap # Server socket
-      - ./hls:/hls
+    # HLS window on tmpfs: host disk-full, read-only remounts and ownership
+    # drift cannot break it. 64M is ~25x the default live window.
+    tmpfs:
+      - /hls:size=64m,uid=100,gid=101,mode=0755
     environment:
       - TZ=${CONTAINER_TIMEZONE:-Europe/Amsterdam}
     env_file:

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,6 @@ DIRECTORIES=(
   "${INSTALL_DIR}/scripts/lib"
   "${INSTALL_DIR}/audio"
   "${INSTALL_DIR}/socket"
-  "${INSTALL_DIR}/hls"
 )
 
 # Environment setup
@@ -227,7 +226,6 @@ EOL
 echo -e "${BLUE}►► Setting ownership...${NC}"
 chown -R 100:101 "${STEREO_TOOL_INSTALL_DIR}"
 chown -R 100:101 "${INSTALL_DIR}/socket"
-chown -R 100:101 "${INSTALL_DIR}/hls"
 
 echo -e "${BLUE}►► Validating Docker Compose configuration...${NC}"
 (cd "${INSTALL_DIR}" && docker compose --env-file .env config -q)


### PR DESCRIPTION
## Problem

Refs #100. Any filesystem error in `output.file.hls` (`EACCES` on the atomic segment rename, `ENOSPC` on a segment write, unwritable directory at startup) escaped the clock streaming loop (`Clock.wrap_errors`, `clock.ml:514`) and shut down the entire Liquidsoap process: Icecast, DAB+ and DME went off air and Docker entered a restart loop while the condition persisted. The existing `mksafe(buffer(...))` wrapper does not help; buffer isolates availability, not exceptions.

## Approach

Two layers, verified against `savonet/liquidsoap:v2.4.5`:

**1. In-process error containment + supervised recovery (`conf/lib/62_output_hls.liq`)**

- The HLS chain runs on a dedicated clock with an `on_error` handler (`clock.assign_new`) - the only containment mechanism 2.4.5 offers. A failing HLS output is detached and logged at error level; every other output keeps running.
- A detached output can never be restarted, so a watchdog recreates a fresh `output.file.hls` with exponential backoff (5s doubling to 300s, reset after 120s of stability) once `HLS_DIR` passes a writability probe. It removes `liq*tmp` leftovers and the previous generation's segments/playlists first; the mirror then retires those remotely.
- `persist_at` is removed. This is load-bearing: with `persist_at` set, the error-detach path calls `#stop` -> `close_segment` (`hls_output.ml:946`, unguarded), which re-raises the same filesystem error on the dead clock thread and kills the process despite the `on_error` handler. Resume state was redundant anyway - segment names are timestamped and never reused.
- The Bunny mirror `thread.run` gets an `on_error` handler: an uncaught error in a scheduler task (e.g. `file.ls` on an unreadable `HLS_DIR`) is an immediate `PANIC`/`_exit 1`, a second independent kill path.
- A preflight probe turns an unwritable directory at startup into a degraded start instead of a crash.
- New `hls.status` server command reports `ok` / `degraded: <reason>` / `disabled` for monitoring.

**2. `/hls` on tmpfs (`docker-compose.yml`, `install.sh`)**

The host bind mount becomes a 64M tmpfs (`uid=100,gid=101,mode=0755`, ~25x the live window), so host disk-full conditions, read-only remounts and ownership drift after deployment cannot reach the HLS writer at all. The installer no longer creates or chowns `./hls`.

## Verification (Docker, savonet/liquidsoap:v2.4.5)

Harness: real `00_settings.liq` + `62_output_hls.liq`, sine source, dummy primary output with a 2s heartbeat, unreachable Bunny endpoint (upload failures are caught and logged, exercising the mirror error paths).

| Scenario | Before | After |
|---|---|---|
| `HLS_DIR` unwritable at startup | process exits (2) | degraded start, primary keeps streaming, auto-start once writable |
| `chmod`/`chown` makes dir unwritable mid-run | process exits (2) | `HLS output degraded (primary outputs unaffected): output: Unix.Unix_error(Unix.EACCES, ...)`, recovery without restart |
| Disk full (tiny tmpfs) | process exits (2) | contained, retried with backoff |
| Recovery | n/a | `HLS output started` + `HLS output recovered`, fresh timestamped generation, stale files cleaned locally and remotely |

Primary heartbeat never missed a beat in any scenario (25/25 over a 42s four-phase run). Syntax validated for all three station configs; `shellcheck`, `yamllint` and `docker compose config` pass; tmpfs ownership verified at runtime.

## Acceptance criteria from #100

- [x] Unwritable `HLS_DIR` does not stop Icecast, DAB or DME
- [x] Disk-full and read-only failures are handled as HLS degradation
- [x] Failure logged at error level and exposed to monitoring (`hls.status`)
- [x] HLS recovers after the filesystem becomes writable again, without restarting primary outputs
- [ ] Automated runtime test in CI (follow-up; the Docker harness used here translates directly)
- [x] Deployment documentation updated (tmpfs sizing and monitoring in README; ownership requirement is gone with tmpfs)
