### PR TITLE
fix: respawn ODR-AudioEnc instead of raising a fatal clock error

### DIFF
--- a/conf/lib/61_output_dab.liq
+++ b/conf/lib/61_output_dab.liq
@@ -45,9 +45,19 @@ def output_dab_stream(audio_source) =
       edi_urls
     )
 
-    # Feed audio to ODR-AudioEnc
+    # Feed audio to ODR-AudioEnc. Without reopen_on_error a dead encoder
+    # raises a fatal clock error that stops the whole process; returning a
+    # delay respawns the encoder instead and leaves other outputs untouched.
     output.external(
       %wav(channels = 2, samplerate = 48000),
+      reopen_on_error=fun (err) ->
+        begin
+          log(
+            "DAB+ encoder error: #{err} - restarting ODR-AudioEnc in 5s",
+            level=2
+          )
+          5.0
+        end,
       odr_command(),
       audio_to_dab
     )


### PR DESCRIPTION
Fixes #110

## Problem

`conf/lib/61_output_dab.liq` feeds odr-audioenc via `output.external` without `reopen_on_error`. The default callback returns `null`, which means: raise the error. That error escapes onto the output's clock and, without a handler, kills the whole Liquidsoap process - the exact same fatal path as the HLS failure fixed in #109.

## Fact-check (reproduced on savonet/liquidsoap:v2.4.5 in Docker, as the issue asked)

All experiments use the repo pattern (`mksafe(buffer(...))` per output), a second dummy output as stand-in for Icecast/DME, a 1s heartbeat thread, and an external command that consumes stdin for 3 seconds and then exits.

1. **Current behavior (no `reopen_on_error`)**: when the external process dies, the next write hits `Sys_error("Broken pipe")` in `pipe_output.ml:433`, the default callback re-raises (`pipe_output.ml:375`), the error reaches `Clock.wrap_errors` (`clock.ml:514`) and the process exits with code 2. All other outputs die with it. The issue's "at worst" scenario is the actual behavior - it is not just the DAB output that crashes.
2. **With `reopen_on_error = fun (_) -> 5.0`**: the process survives, the encoder is respawned after the delay every cycle, the heartbeat and the other output keep running throughout, and Liquidsoap itself logs `Error while streaming: ... will re-open in 5.00s` at level 3 next to our level-2 log.
3. **Startup failure (binary missing)**: also covered by `reopen_on_error` - retried every cycle with visible log lines instead of killing the process.
4. **End-to-end with the actual patched `61_output_dab.liq`**: mounted a fake `/bin/odr-audioenc` that dies after 3s into the container with `DAB_BITRATE`/`DAB_EDI_DESTINATIONS` set; the command line is built correctly, the encoder respawned every ~8s (3s run + 5s delay), and the process stayed alive with all outputs running.

## Fix

One parameter on `output.external`, as proposed in the issue: `reopen_on_error` returning `5.0`, with a level-2 log of the error (mirrors the HLS degraded logging) so respawns are visible in the Docker logs. No watchdog machinery needed - `output.external` has this recovery hook natively.

Note: the issue also suggested optionally using `on_reopen` for logging; that argument is deprecated in 2.4.5 ("please use the source method"), so logging lives in the `reopen_on_error` callback instead.

## Acceptance criteria from the issue

- [x] Repro confirms current behavior is process-fatal
- [x] With `reopen_on_error`: process survives, encoder respawned after the delay, all other outputs keep running
- [x] Respawn attempts visible in the logs (level 2 callback log + built-in level 3 "will re-open" line)

CI-relevant checks run locally: `liquidsoap -c` on all three station files in the v2.4.5 Docker image (pass) and `liquidsoap-prettier` formatting applied.