### PR TITLE
fix: apply Debian updates in weekly image rebuilds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,17 +20,21 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get Software Versions
         id: versions
@@ -50,30 +54,30 @@ jobs:
             echo "combined_tag=$COMBINED_TAG"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU for Update Check
+        if: github.event_name == 'schedule'
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+
       - name: Determine if Build Is Needed
         id: check_version
         env:
+          COMBINED_TAG: ${{ steps.versions.outputs.combined_tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          FORCE_BUILD: ${{ inputs.force_build }}
           GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository }}:latest
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [[ "${{ github.event.inputs.force_build }}" == "true" ]]; then
+          if [[ "$FORCE_BUILD" == "true" ]]; then
             echo "Force build enabled, proceeding with build"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            # Skip only when the check succeeds and finds no pending upgrade
-            docker run --rm --user root --entrypoint sh "ghcr.io/${{ github.repository }}:latest" -c \
-              'apt-get update -qq && apt-get -s upgrade >/tmp/upgrades && ! grep -q "^Inst " /tmp/upgrades' \
-              && SHOULD_BUILD=false || SHOULD_BUILD=true
-            echo "Scheduled build required: $SHOULD_BUILD"
-            echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          COMBINED_TAG="${{ steps.versions.outputs.combined_tag }}"
-          REPO_NAME=$(basename "${{ github.repository }}")
-          ORG_NAME=$(dirname "${{ github.repository }}")
+          REPO_NAME=$(basename "$REPOSITORY")
+          ORG_NAME=$(dirname "$REPOSITORY")
 
           echo "Checking if version exists: $COMBINED_TAG"
           EXISTING_TAGS=$(gh api "orgs/${ORG_NAME}/packages/container/${REPO_NAME}/versions" \
@@ -85,16 +89,34 @@ jobs:
           echo "$EXISTING_TAGS"
           echo "---"
 
-          if echo "$EXISTING_TAGS" | grep -q "^$COMBINED_TAG$"; then
-            echo "Version already exists: $COMBINED_TAG"
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          else
+          if ! grep -Fxq -- "$COMBINED_TAG" <<< "$EXISTING_TAGS"; then
             echo "Version not found. Will build: $COMBINED_TAG"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Set up QEMU
-        if: steps.check_version.outputs.should_build == 'true'
+          if [[ "$EVENT_NAME" != "schedule" ]]; then
+            echo "Version already exists: $COMBINED_TAG"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Skip only when both platform checks succeed without pending upgrades
+          for PLATFORM in linux/amd64 linux/arm64; do
+            echo "Checking package updates for $PLATFORM"
+            if ! docker run --rm --platform "$PLATFORM" --user root --entrypoint sh "$IMAGE" -c \
+              'apt-get update -qq && apt-get -s upgrade >/tmp/upgrades && ! grep -q "^Inst " /tmp/upgrades'; then
+              echo "Scheduled build required for $PLATFORM"
+              echo "should_build=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "Published image is up to date on both platforms"
+          echo "should_build=false" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU for Build
+        if: github.event_name != 'schedule' && steps.check_version.outputs.should_build == 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -135,24 +157,31 @@ jobs:
 
       - name: Build Summary
         if: steps.check_version.outputs.should_build == 'true'
+        env:
+          COMBINED_TAG: ${{ steps.versions.outputs.combined_tag }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          FORCE_BUILD: ${{ inputs.force_build }}
+          IMAGE: ghcr.io/${{ github.repository }}:${{ steps.versions.outputs.combined_tag }}
         run: |
           {
             echo "## Docker Build Completed Successfully"
-            echo "- **Image Tag**: ${{ steps.versions.outputs.combined_tag }}"
-            echo "- **Image**: ghcr.io/${{ github.repository }}:${{ steps.versions.outputs.combined_tag }}"
-            echo "- **Digest**: ${{ steps.build.outputs.digest }}"
+            echo "- **Image Tag**: $COMBINED_TAG"
+            echo "- **Image**: $IMAGE"
+            echo "- **Digest**: $DIGEST"
             echo "- **Platforms**: linux/amd64, linux/arm64"
-            if [[ "${{ github.event.inputs.force_build }}" == "true" ]]; then
+            if [[ "$FORCE_BUILD" == "true" ]]; then
               echo "- **Force Build**: Enabled"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Skip Build Summary
         if: steps.check_version.outputs.should_build == 'false'
+        env:
+          COMBINED_TAG: ${{ steps.versions.outputs.combined_tag }}
         run: |
           {
             echo "## Docker Build Skipped"
-            echo "No build required for version ${{ steps.versions.outputs.combined_tag }}"
+            echo "No build required for version $COMBINED_TAG"
             echo "Use 'Force build' option to rebuild existing version"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set up QEMU for Update Check
         if: github.event_name == 'schedule'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
@@ -118,15 +118,15 @@ jobs:
 
       - name: Set up QEMU for Build
         if: github.event_name != 'schedule' && steps.check_version.outputs.should_build == 'true'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: steps.check_version.outputs.should_build == 'true'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: steps.check_version.outputs.should_build == 'true'
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -135,7 +135,7 @@ jobs:
       - name: Build and Push Docker Image
         if: steps.check_version.outputs.should_build == 'true'
         id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -198,7 +198,7 @@ jobs:
       # deletes only truly unreferenced manifests; arch children of tagged
       # manifest lists are preserved.
       - name: Delete orphaned untagged images
-        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           packages: zwfm-liquidsoap
           validate: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,13 @@ on:
         default: "false"
         type: boolean
   workflow_call:
+  schedule:
+    # Weekly rebuild so published images pick up Debian security updates
+    - cron: "0 3 * * 1"
+
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -43,20 +50,28 @@ jobs:
             echo "combined_tag=$COMBINED_TAG"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Check if Version Exists
+      - name: Determine if Build Is Needed
         id: check_version
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMBINED_TAG="${{ steps.versions.outputs.combined_tag }}"
-          FORCE_BUILD="${{ github.event.inputs.force_build }}"
-
-          if [[ "$FORCE_BUILD" == "true" ]]; then
+          if [[ "${{ github.event.inputs.force_build }}" == "true" ]]; then
             echo "Force build enabled, proceeding with build"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # Skip only when the check succeeds and finds no pending upgrade
+            docker run --rm --user root --entrypoint sh "ghcr.io/${{ github.repository }}:latest" -c \
+              'apt-get update -qq && apt-get -s upgrade >/tmp/upgrades && ! grep -q "^Inst " /tmp/upgrades' \
+              && SHOULD_BUILD=false || SHOULD_BUILD=true
+            echo "Scheduled build required: $SHOULD_BUILD"
+            echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          COMBINED_TAG="${{ steps.versions.outputs.combined_tag }}"
           REPO_NAME=$(basename "${{ github.repository }}")
           ORG_NAME=$(dirname "${{ github.repository }}")
 
@@ -137,7 +152,7 @@ jobs:
         run: |
           {
             echo "## Docker Build Skipped"
-            echo "Version ${{ steps.versions.outputs.combined_tag }} already exists"
+            echo "No build required for version ${{ steps.versions.outputs.combined_tag }}"
             echo "Use 'Force build' option to rebuild existing version"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,13 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to publish images to GHCR
       packages: write
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -56,7 +57,7 @@ jobs:
 
       - name: Set up QEMU for Update Check
         if: github.event_name == 'schedule'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
         with:
           platforms: arm64
 
@@ -117,15 +118,15 @@ jobs:
 
       - name: Set up QEMU for Build
         if: github.event_name != 'schedule' && steps.check_version.outputs.should_build == 'true'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
         if: steps.check_version.outputs.should_build == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
         if: steps.check_version.outputs.should_build == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -134,7 +135,7 @@ jobs:
       - name: Build and Push Docker Image
         if: steps.check_version.outputs.should_build == 'true'
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile
@@ -197,7 +198,7 @@ jobs:
       # deletes only truly unreferenced manifests; arch children of tagged
       # manifest lists are preserved.
       - name: Delete orphaned untagged images
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1
         with:
           packages: zwfm-liquidsoap
           validate: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETARCH
 
 USER root
 RUN apt-get update \
- && apt-get install -y --no-install-recommends --only-upgrade libssl3t64 openssl libgdk-pixbuf-2.0-0 \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends iproute2 wget \
  && wget -q -O /bin/odr-audioenc "https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/odr-audioenc-${ODR_AUDIOENC_VERSION}/odr-audioenc-${ODR_AUDIOENC_VERSION}-minimal-debian13-${TARGETARCH}" \
  && chmod +x /bin/odr-audioenc \


### PR DESCRIPTION
## Summary

Fixes the open Debian package alerts without adding CVE-specific maintenance logic.

- Replace the hand-maintained `--only-upgrade` package list with `apt-get upgrade -y`, so every normal Debian package update is applied during a build.
- Add a weekly schedule that asks the published `:latest` image whether upgrades are pending. A successful check with no upgrades skips publishing; an available upgrade or any check failure uses the existing build path.
- Rely on the existing `no-cache: true` in the shared security workflow; no local cache-busting argument is needed.

The update gate uses only Docker, Debian package tools, and command exit status. It does not count or capture upgrade output and needs no separate failure branch. Layer comparison would require building first and would compare byte-level metadata rather than package state; registries already deduplicate byte-identical layers during push.

## Verification

- Rebases cleanly onto current `main`, retaining `iproute2`, the DAB TCP ACK monitor, and GHCR cleanup.
- Fresh no-cache `linux/amd64` build succeeds.
- The build upgraded 32 packages; `libssh2-1t64` is `1.11.1-1+deb13u1`.
- Scheduled gate: fresh image yields `should_build=false`; stale base image and failed image lookup both yield `should_build=true`.
- Liquidsoap 2.4.5 starts; ODR-AudioEnc, `ss`, and the DAB monitor are present and executable.
- Trivy 0.69.3 reports 0 fixable MEDIUM/HIGH/CRITICAL vulnerabilities.
- actionlint, yamllint, hadolint, the DAB monitor tests, and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly automated build check every Monday at 03:00 UTC, alongside existing manual and reusable triggers.
  * Scheduled runs now verify the currently published image for pending upgrades and rebuild only when needed.
  * Preserved the option to force a build when required.
* **Bug Fixes**
  * Improved image maintenance by switching to a full system upgrade during builds.
  * Refined build success/skip messages to provide clearer tag, image reference, digest, and platform details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->