### PR TITLE
fix: accept stream metadata via POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ PAD allows sending metadata like song titles and station logos alongside the aud
 
 ## Shared Stream Metadata
 
-When `STREAM_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts now-playing updates at `GET /metadata` on `STREAM_METADATA_PORT`. Metadata is inserted into the main radio source before processing and the output fan-out. One update therefore reaches every compatible Liquidsoap stream output:
+When `STREAM_METADATA_BEARER_TOKEN` is configured, Liquidsoap accepts now-playing updates at `POST /metadata` on `STREAM_METADATA_PORT`. Metadata is inserted into the main radio source before processing and the output fan-out. One update therefore reaches every compatible Liquidsoap stream output:
 
 - Icecast MP3 and AAC mounts
 - DME Icecast mounts for Radio Rucphen and BredaNu
@@ -360,15 +360,16 @@ DAB+ PAD and StereoTool/RDS remain protocol-specific metadata outputs. DAB uses 
 Any metadata producer can call the endpoint. For example:
 
 ```bash
-curl --get http://127.0.0.1:7000/metadata \
+curl http://127.0.0.1:7000/metadata \
+  --request POST \
   --header "Authorization: Bearer ${STREAM_METADATA_BEARER_TOKEN}" \
-  --data-urlencode "title=Song title" \
-  --data-urlencode "artist=Artist name"
+  --header "Content-Type: application/json" \
+  --data '{"title":"Song title","artist":"Artist name"}'
 ```
 
 The only requirements are a non-empty `title`, an optional `artist`, and the configured bearer token.
 
-The endpoint returns `204 No Content` on success, `400 Bad Request` when `title` is missing, and `401 Unauthorized` when the bearer token is missing or wrong. Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
+The endpoint returns `204 No Content` on success, `400 Bad Request` when the JSON body is invalid or `title` is missing, and `401 Unauthorized` when the bearer token is missing or wrong. Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
 
 As an optional integration, configure one URL output in [zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired input priority, filters, and delay:
 
@@ -380,14 +381,14 @@ As an optional integration, configure one URL output in [zwfm-metadata](https://
   "formatters": [],
   "settings": {
     "delay": 0,
-    "url": "http://liquidsoap:7000/metadata?title={{.title}}&artist={{.artist}}",
-    "method": "GET",
+    "url": "http://liquidsoap:7000/metadata",
+    "method": "POST",
     "bearerToken": "replace-with-the-same-long-random-token"
   }
 }
 ```
 
-The URL template fields are URL-encoded by `zwfm-metadata`. When using that integration, this single output can replace direct Icecast metadata outputs for mounts produced by this Liquidsoap instance.
+The POST body contains the structured metadata JSON from `zwfm-metadata`. Liquidsoap reads the `title` and `artist` fields and ignores other fields. When using this integration, this single output can replace direct Icecast metadata outputs for mounts produced by this Liquidsoap instance.
 
 Keep the endpoint on a private network. The Compose configuration binds it to `127.0.0.1` by default. When both applications run in containers, attach them to the same Docker network and use the `liquidsoap` service name. For a metadata service on another host, use a trusted private or VPN network, or place the endpoint behind a TLS reverse proxy. If binding to `0.0.0.0`, restrict the port with a firewall to that host and never expose the raw HTTP endpoint to an untrusted network.
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ curl http://127.0.0.1:7000/metadata \
 
 The only requirements are a non-empty `title`, an optional `artist`, and the configured bearer token.
 
-The endpoint returns `204 No Content` on success, `400 Bad Request` when the JSON body is invalid or `title` is missing, `401 Unauthorized` when the bearer token is missing or wrong, and `413 Payload Too Large` when the body exceeds 16 KiB or uses chunked transfer encoding. Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
+The endpoint returns `204 No Content` on success, `400 Bad Request` when the JSON body is invalid or `title` is missing, `401 Unauthorized` when the bearer token is missing or wrong, and `413 Payload Too Large` when the body exceeds 16 KiB or uses a `Transfer-Encoding` header (chunked bodies are not supported). Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
 
 As an optional integration, configure one URL output in [zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired input priority, filters, and delay:
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ curl http://127.0.0.1:7000/metadata \
 
 The only requirements are a non-empty `title`, an optional `artist`, and the configured bearer token.
 
-The endpoint returns `204 No Content` on success, `400 Bad Request` when the JSON body is invalid or `title` is missing, and `401 Unauthorized` when the bearer token is missing or wrong. Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
+The endpoint returns `204 No Content` on success, `400 Bad Request` when the JSON body is invalid or `title` is missing, `401 Unauthorized` when the bearer token is missing or wrong, and `413 Payload Too Large` when the body exceeds 16 KiB or uses chunked transfer encoding. Omitting `artist` sends a title-only update. When no bearer token is configured, the metadata endpoint is not registered, so connection failures are expected. Otherwise, verify the container health, configured bind address and port, and firewall rules.
 
 As an optional integration, configure one URL output in [zwfm-metadata](https://github.com/oszuidwest/zwfm-metadata) with the desired input priority, filters, and delay:
 

--- a/conf/lib/42_metadata.liq
+++ b/conf/lib/42_metadata.liq
@@ -40,39 +40,52 @@ def register_stream_metadata_endpoint(radio_source) =
         res.status_code(401)
         res.data("Unauthorized\n")
       else
-        let title = req.query["title"]
-        let artist = req.query["artist"]
+        try
+          let json.parse ({title, artist} : {title: string, artist: string?}) =
+            req.body()
+          let artist = artist ?? ""
 
-        if
-          title == ""
-        then
+          if
+            title == ""
+          then
+            log(
+              label="metadata",
+              "Rejected metadata request: missing title",
+              level=3
+            )
+            res.status_code(400)
+            res.data(
+              "Missing title\n"
+            )
+          else
+            # An omitted artist sends a title-only update instead of an empty
+            # artist tag
+            let new_metadata =
+              if
+                artist == ""
+              then
+                [("title", title)]
+              else
+                [("artist", artist), ("title", title)]
+              end
+
+            radio_source.insert_metadata(new_metadata)
+            res.status_code(204)
+            log(
+              label="metadata",
+              "Inserted stream metadata: artist='#{artist}' title='#{title}'",
+              level=3
+            )
+          end
+        catch err : [error.json] do
           log(
             label="metadata",
-            "Rejected metadata request: missing title",
+            "Rejected metadata request: invalid JSON body: #{err.message}",
             level=3
           )
           res.status_code(400)
           res.data(
-            "Missing title\n"
-          )
-        else
-          # An omitted artist sends a title-only update instead of an empty
-          # artist tag
-          let new_metadata =
-            if
-              artist == ""
-            then
-              [("title", title)]
-            else
-              [("artist", artist), ("title", title)]
-            end
-
-          radio_source.insert_metadata(new_metadata)
-          res.status_code(204)
-          log(
-            label="metadata",
-            "Inserted stream metadata: artist='#{artist}' title='#{title}'",
-            level=3
+            "Invalid JSON body\n"
           )
         end
       end
@@ -80,7 +93,7 @@ def register_stream_metadata_endpoint(radio_source) =
 
     harbor.http.register(
       port=STREAM_METADATA_PORT,
-      method="GET",
+      method="POST",
       "/metadata",
       stream_metadata_handler
     )

--- a/conf/lib/42_metadata.liq
+++ b/conf/lib/42_metadata.liq
@@ -24,23 +24,6 @@ def read_stream_metadata_body(req) =
   read_stream_metadata_chunks("")
 end
 
-def stream_metadata_body_too_large(req) =
-  # Liquidsoap buffers each chunked HTTP chunk before req.data() returns it,
-  # so chunked bodies cannot be bounded safely inside the handler.
-  if
-    req.headers["transfer-encoding"] != ""
-  then
-    true
-  else
-    try
-      int_of_string(req.headers["content-length"]) >
-        STREAM_METADATA_MAX_BODY_BYTES
-    catch _ do
-      false
-    end
-  end
-end
-
 def register_stream_metadata_endpoint(radio_source) =
   if
     STREAM_METADATA_BEARER_TOKEN == ""
@@ -88,13 +71,14 @@ def register_stream_metadata_endpoint(radio_source) =
           "bad or missing bearer token"
         )
       elsif
-        stream_metadata_body_too_large(req)
+        # Liquidsoap buffers each chunked HTTP chunk before req.data() returns
+        # it, so chunked bodies cannot be bounded inside the handler
+        req.headers["transfer-encoding"] != ""
       then
         reject(
           413,
           "Payload Too Large\n",
-          "body exceeds #{STREAM_METADATA_MAX_BODY_BYTES} bytes or uses \
-           unsupported transfer encoding"
+          "unsupported transfer encoding"
         )
       else
         let request_body = read_stream_metadata_body(req)

--- a/conf/lib/42_metadata.liq
+++ b/conf/lib/42_metadata.liq
@@ -1,6 +1,46 @@
 # Shared stream metadata endpoint
 # Inserts authenticated now-playing updates before the output fan-out.
 
+let STREAM_METADATA_MAX_BODY_BYTES = 16_384
+
+def read_stream_metadata_body(req) =
+  def rec read_stream_metadata_chunks(body) =
+    let chunk = req.data()
+
+    if
+      chunk == ""
+    then
+      {body = body, too_large = false}
+    elsif
+      string.bytes.length(body) + string.bytes.length(chunk) >
+        STREAM_METADATA_MAX_BODY_BYTES
+    then
+      {body = "", too_large = true}
+    else
+      read_stream_metadata_chunks(body ^ chunk)
+    end
+  end
+
+  read_stream_metadata_chunks("")
+end
+
+def stream_metadata_body_too_large(req) =
+  # Liquidsoap buffers each chunked HTTP chunk before req.data() returns it,
+  # so chunked bodies cannot be bounded safely inside the handler.
+  if
+    req.headers["transfer-encoding"] != ""
+  then
+    true
+  else
+    try
+      int_of_string(req.headers["content-length"]) >
+        STREAM_METADATA_MAX_BODY_BYTES
+    catch _ do
+      false
+    end
+  end
+end
+
 def register_stream_metadata_endpoint(radio_source) =
   if
     STREAM_METADATA_BEARER_TOKEN == ""
@@ -27,66 +67,88 @@ def register_stream_metadata_endpoint(radio_source) =
     def stream_metadata_handler(req, res) =
       res.header("Cache-Control", "no-store")
 
+      def reject(code, body, reason) =
+        log(
+          label="metadata",
+          "Rejected metadata request: #{reason}",
+          level=3
+        )
+        res.status_code(code)
+        res.data(body)
+      end
+
       # Harbor lowercases incoming header names before handlers run
       if
         req.headers["authorization"] !=
           "Bearer #{STREAM_METADATA_BEARER_TOKEN}"
       then
-        log(
-          label="metadata",
-          "Rejected metadata request: bad or missing bearer token",
-          level=3
+        reject(
+          401,
+          "Unauthorized\n",
+          "bad or missing bearer token"
         )
-        res.status_code(401)
-        res.data("Unauthorized\n")
+      elsif
+        stream_metadata_body_too_large(req)
+      then
+        reject(
+          413,
+          "Payload Too Large\n",
+          "body exceeds #{STREAM_METADATA_MAX_BODY_BYTES} bytes or uses \
+           unsupported transfer encoding"
+        )
       else
-        try
-          let json.parse ({title, artist} : {title: string, artist: string?}) =
-            req.body()
-          let artist = artist ?? ""
+        let request_body = read_stream_metadata_body(req)
 
-          if
-            title == ""
-          then
-            log(
-              label="metadata",
-              "Rejected metadata request: missing title",
-              level=3
-            )
-            res.status_code(400)
-            res.data(
-              "Missing title\n"
-            )
-          else
-            # An omitted artist sends a title-only update instead of an empty
-            # artist tag
-            let new_metadata =
-              if
-                artist == ""
-              then
-                [("title", title)]
-              else
-                [("artist", artist), ("title", title)]
-              end
+        if
+          request_body.too_large
+        then
+          reject(
+            413,
+            "Payload Too Large\n",
+            "body exceeds #{STREAM_METADATA_MAX_BODY_BYTES} bytes"
+          )
+        else
+          try
+            let json.parse ({title, artist} :
+              {title: string, artist: string?}
+            ) = request_body.body
+            let artist = artist ?? ""
 
-            radio_source.insert_metadata(new_metadata)
-            res.status_code(204)
-            log(
-              label="metadata",
-              "Inserted stream metadata: artist='#{artist}' title='#{title}'",
-              level=3
+            if
+              title == ""
+            then
+              reject(
+                400,
+                "Missing title\n",
+                "missing title"
+              )
+            else
+              # An omitted artist sends a title-only update instead of an empty
+              # artist tag
+              let new_metadata =
+                if
+                  artist == ""
+                then
+                  [("title", title)]
+                else
+                  [("artist", artist), ("title", title)]
+                end
+
+              radio_source.insert_metadata(new_metadata)
+              res.status_code(204)
+              log(
+                label="metadata",
+                "Inserted stream metadata: artist='#{artist}' title='#{title}'",
+                level=3
+              )
+            end
+          catch err : [error.json] do
+            reject(
+              400,
+              "Invalid JSON body\n",
+              "invalid JSON body: #{err.message}"
             )
           end
-        catch err : [error.json] do
-          log(
-            label="metadata",
-            "Rejected metadata request: invalid JSON body: #{err.message}",
-            level=3
-          )
-          res.status_code(400)
-          res.data(
-            "Invalid JSON body\n"
-          )
         end
       end
     end

--- a/conf/lib/42_metadata.liq
+++ b/conf/lib/42_metadata.liq
@@ -65,6 +65,10 @@ def register_stream_metadata_endpoint(radio_source) =
         req.headers["authorization"] !=
           "Bearer #{STREAM_METADATA_BEARER_TOKEN}"
       then
+        res.header(
+          "WWW-Authenticate",
+          "Bearer realm=\"metadata\""
+        )
         reject(
           401,
           "Unauthorized\n",
@@ -122,7 +126,7 @@ def register_stream_metadata_endpoint(radio_source) =
               res.status_code(204)
               log(
                 label="metadata",
-                "Inserted stream metadata: artist='#{artist}' title='#{title}'",
+                "Inserted stream metadata",
                 level=3
               )
             end


### PR DESCRIPTION
## Summary

- replace the state-changing GET metadata endpoint with POST
- parse and validate title and optional artist from a JSON request body
- update the curl and zwfm-metadata configuration examples

## Testing

- liquidsoap-prettier formatting check for all Liquidsoap files
- Liquidsoap 2.4.5 syntax checks for all station configurations
- runtime smoke tests for valid, title-only, malformed, unauthorized, and legacy GET requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The shared stream metadata endpoint now uses **POST** with **JSON** in the request body and **Bearer auth** via the `Authorization` header.
  - Requires a **non-empty `title`**; `artist` is optional (title-only updates supported).
  - On success returns **`204 No Content`** with **`Cache-Control: no-store`**.

- **Bug Fixes**
  - Added stricter validation: **`400`** for invalid/missing `title`, **`401`** for bad/missing auth.
  - Enforces a **16 KiB** body limit and rejects unsupported/non-empty `transfer-encoding` with **`413 Payload Too Large`**.

- **Documentation**
  - Updated README `curl` examples and integration snippet to match the new POST contract and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->