### PR TITLE
refactor: install ODR-AudioEnc in local bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ USER root
 RUN apt-get update \
  && apt-get upgrade -y --no-install-recommends \
  && apt-get install -y --no-install-recommends iproute2 wget \
- && wget -q -O /bin/odr-audioenc "https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/odr-audioenc-${ODR_AUDIOENC_VERSION}/odr-audioenc-${ODR_AUDIOENC_VERSION}-minimal-debian13-${TARGETARCH}" \
- && chmod +x /bin/odr-audioenc \
+ && wget -q -O /usr/local/bin/odr-audioenc "https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/odr-audioenc-${ODR_AUDIOENC_VERSION}/odr-audioenc-${ODR_AUDIOENC_VERSION}-minimal-debian13-${TARGETARCH}" \
+ && chmod +x /usr/local/bin/odr-audioenc \
  && apt-get remove -y wget \
  && apt-get autoremove -y \
  && apt-get clean \

--- a/conf/lib/61_output_dab.liq
+++ b/conf/lib/61_output_dab.liq
@@ -139,7 +139,7 @@ def output_dab_stream(audio_source) =
     let edi_args = dab_edi_args(DAB_EDI_DESTINATIONS)
     let odr_command =
       process.quote.command(
-        "/bin/odr-audioenc",
+        "/usr/local/bin/odr-audioenc",
         args=list.flatten(
           [["-i", "-", "--bitrate=#{DAB_BITRATE}", "--sbr"], pad_args, edi_args]
         )


### PR DESCRIPTION
## Summary

- install the project-provided ODR-AudioEnc binary in /usr/local/bin
- keep the Liquidsoap command path aligned with its install location
- intentionally remove support for the old /bin/odr-audioenc path

## Validation

- fresh linux/amd64 Docker build with --pull --no-cache
- verified command -v odr-audioenc resolves to /usr/local/bin/odr-audioenc
- verified /bin/odr-audioenc is absent
- validated every conf/*.liq file with the built image
- ran tests/test-dab-output.liq
- ran tests/test-dab-tcp-ack-monitor.sh
- ran hadolint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the DAB+ audio encoder installation and runtime path to ensure the encoder is found and executed correctly.
  * Preserved existing encoding options, monitoring behavior, and stream configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->